### PR TITLE
Move Clippy & Rust-fmt back to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/style_checks.yml
+++ b/.github/workflows/style_checks.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   check_clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: apt install gstreamer
@@ -30,7 +30,7 @@ jobs:
 
   check_fmt:
     name: Rust-fmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,8 @@ use validator::Validate;
 
 mod cmdline;
 mod config;
-mod pir;
 mod mqtt;
+mod pir;
 mod reboot;
 mod rtsp;
 mod statusled;


### PR DESCRIPTION
Get these working again, the issue causing their breakage on 22.04 can be diagnosed later.