### PR TITLE
Battery message and requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,7 @@ dependencies = [
  "nom",
  "rand",
  "regex",
+ "serde",
  "socket2 0.3.19",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ description = "A standards-compliant bridge to Reolink IP cameras"
 version = "0.5.4"
 authors = ["George Hilliard <thirtythreeforty@gmail.com>", "Andrew King <sheepchaan@gmail.com>"]
 edition = "2018"
-default-run = "neolink"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "A standards-compliant bridge to Reolink IP cameras"
 version = "0.5.4"
 authors = ["George Hilliard <thirtythreeforty@gmail.com>", "Andrew King <sheepchaan@gmail.com>"]
 edition = "2018"
+default-run = "neolink"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ Control messages:
 Status Messages:
 `/status offline` Sent when the neolink goes offline this is a LastWill message
 `/status disconnected` Sent when the camera goes offline
-`/status/battery` Sent in reply to a `/query/battery`
+`/status/battery` Sent in reply to a `/query/battery` send an XML encoded version of the battery status
 
 Query Messages:
-`/query/battery` Request that the camera reports its battery level (Not Yet Implemented)
+`/query/battery` Request that the camera reports its battery level
 
 ### Pause
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ md5 = "0.7"
 nom = { version = "6.1.2", features = ["alloc"] }
 rand = "0.8.4"
 regex = "1.5.4"
+serde = { version = "1.0", features = ["derive"] }
 socket2 = "0.3"
 time = "0.2"
 tokio = { version = "1.24.2", features = ["full"] }

--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -47,6 +47,10 @@ pub const MSG_ID_GET_LED_STATUS: u32 = 208;
 pub const MSG_ID_SET_LED_STATUS: u32 = 209;
 /// UDP Keep alive
 pub const MSG_ID_UDP_KEEP_ALIVE: u32 = 234;
+/// Battery message initiaed by the camera
+pub const MSG_ID_BATTERY_INFO_LIST: u32 = 252;
+/// Battery message initiaed by the client
+pub const MSG_ID_BATTERY_INFO: u32 = 253;
 
 /// An empty password in legacy format
 pub const EMPTY_LEGACY_PASSWORD: &str =

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -487,7 +487,7 @@ pub struct BatteryInfo {
     /// The channel the for the camera usually 0
     #[yaserde(rename = "channelId")]
     pub channel_id: u8,
-    /// Charge status known values, "chargeComplete", "charging",
+    /// Charge status known values, "chargeComplete", "charging", "none",
     #[yaserde(rename = "chargeStatus")]
     pub charge_status: String,
     /// Status of charging port known values: "solarPanel"

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -487,7 +487,7 @@ pub struct BatteryInfo {
     /// The channel the for the camera usually 0
     #[yaserde(rename = "channelId")]
     pub channel_id: u8,
-    /// Charge status known values, "chargeComplete", "charging",
+    /// Charge status known values, "chargeComplete", "charging", "none",
     #[yaserde(rename = "chargeStatus")]
     pub charge_status: String,
     /// Status of charging port known values: "solarPanel"
@@ -508,6 +508,9 @@ pub struct BatteryInfo {
     /// Battery version info: Known values 2
     #[yaserde(rename = "batteryVersion")]
     pub battery_version: u32,
+}
+
+/// ,
 }
 
 /// Convience function to return the xml version used throughout the library
@@ -678,5 +681,3 @@ fn test_binary_deser() {
             ..
         } => {}
         _ => panic!(),
-    }
-}

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -487,7 +487,7 @@ pub struct BatteryInfo {
     /// The channel the for the camera usually 0
     #[yaserde(rename = "channelId")]
     pub channel_id: u8,
-    /// Charge status known values, "chargeComplete", "charging", "none",
+    /// Charge status known values, "chargeComplete", "charging",
     #[yaserde(rename = "chargeStatus")]
     pub charge_status: String,
     /// Status of charging port known values: "solarPanel"
@@ -508,9 +508,6 @@ pub struct BatteryInfo {
     /// Battery version info: Known values 2
     #[yaserde(rename = "batteryVersion")]
     pub battery_version: u32,
-}
-
-/// ,
 }
 
 /// Convience function to return the xml version used throughout the library
@@ -681,3 +678,5 @@ fn test_binary_deser() {
             ..
         } => {}
         _ => panic!(),
+    }
+}

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -76,6 +76,12 @@ pub struct BcXml {
     /// Sent to move the camera
     #[yaserde(rename = "PtzControl")]
     pub ptz_control: Option<PtzControl>,
+    /// Recieved on login/low battery events
+    #[yaserde(rename = "BatteryList")]
+    pub battery_list: Option<BatteryList>,
+    /// Recieved on request for battery info
+    #[yaserde(rename = "BatteryInfo")]
+    pub battery_info: Option<BatteryInfo>,
 }
 
 impl BcXml {
@@ -461,6 +467,47 @@ pub struct PtzControl {
     pub speed: f32,
     /// The direction to transverse. Known directions: "right"
     pub command: String,
+}
+
+/// A list of battery infos. This message is sent from the camera as
+/// an event
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct BatteryList {
+    /// XML Version
+    #[yaserde(attribute)]
+    pub version: String,
+    /// Battery info items
+    #[yaserde(rename = "BatteryInfo")]
+    pub battery_info: Vec<BatteryInfo>,
+}
+
+/// The individual battery info
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct BatteryInfo {
+    /// The channel the for the camera usually 0
+    #[yaserde(rename = "channelId")]
+    pub channel_id: u8,
+    /// Charge status known values, "chargeComplete", "charging",
+    #[yaserde(rename = "chargeStatus")]
+    pub charge_status: String,
+    /// Status of charging port known values: "solarPanel"
+    #[yaserde(rename = "adapterStatus")]
+    pub adapter_status: String,
+    /// Voltage
+    pub voltage: u32,
+    /// Current
+    pub current: u32,
+    /// Temperture
+    pub temperature: u32,
+    /// % charge from 0-100
+    #[yaserde(rename = "batteryPercent")]
+    pub battery_percent: u32,
+    /// Low power flag. Known values 0, 1 (0=false)
+    #[yaserde(rename = "lowPower")]
+    pub low_power: u32,
+    /// Battery version info: Known values 2
+    #[yaserde(rename = "batteryVersion")]
+    pub battery_version: u32,
 }
 
 /// Convience function to return the xml version used throughout the library

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -494,11 +494,11 @@ pub struct BatteryInfo {
     #[yaserde(rename = "adapterStatus")]
     pub adapter_status: String,
     /// Voltage
-    pub voltage: u32,
+    pub voltage: i32,
     /// Current
-    pub current: u32,
+    pub current: i32,
     /// Temperture
-    pub temperature: u32,
+    pub temperature: i32,
     /// % charge from 0-100
     #[yaserde(rename = "batteryPercent")]
     pub battery_percent: u32,

--- a/crates/core/src/bc_protocol.rs
+++ b/crates/core/src/bc_protocol.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 
 use Md5Trunc::*;
 
+mod battery;
 mod connection;
 mod credentials;
 mod errors;
@@ -306,6 +307,7 @@ impl BcCamera {
             credentials: Credentials::new(username, passwd),
         };
         me.keepalive().await?;
+        me.monitor_battery().await?;
         Ok(me)
     }
 

--- a/crates/core/src/bc_protocol.rs
+++ b/crates/core/src/bc_protocol.rs
@@ -1,6 +1,7 @@
 use crate::bc;
 use futures::stream::StreamExt;
 use log::*;
+use serde::{Deserialize, Serialize};
 use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 
@@ -51,6 +52,20 @@ pub struct BcCamera {
     credentials: Credentials,
 }
 
+/// Used to choode the print format of various status messages like battery levels
+///
+/// Currently this is just the format of battery levels but if we ever got more status
+/// messages then they will also use this information
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum PrintFormat {
+    /// None, don't print
+    None,
+    /// A human readable output
+    Human,
+    /// Xml formatted
+    Xml,
+}
+
 impl BcCamera {
     ///
     /// Create a new camera interface with this address and channel ID
@@ -70,6 +85,7 @@ impl BcCamera {
         channel_id: u8,
         username: V,
         passwd: Option<W>,
+        aux_info_format: PrintFormat,
     ) -> Result<Self> {
         let username: String = username.into();
         let passwd: Option<String> = passwd.map(|t| t.into());
@@ -83,6 +99,7 @@ impl BcCamera {
                 channel_id,
                 &username,
                 passwd.as_ref(),
+                aux_info_format,
             )
             .await
             {
@@ -112,12 +129,14 @@ impl BcCamera {
         username: U,
         passwd: Option<V>,
         discovery_method: DiscoveryMethods,
+        aux_info_format: PrintFormat,
     ) -> Result<Self> {
         Self::new(
             SocketAddrOrUid::Uid(uid.to_string(), discovery_method),
             channel_id,
             username,
             passwd,
+            aux_info_format,
         )
         .await
     }
@@ -147,6 +166,7 @@ impl BcCamera {
         channel_id: u8,
         username: V,
         passwd: Option<W>,
+        aux_info_format: PrintFormat,
     ) -> Result<Self> {
         let addr_iter = match host.to_socket_addrs_or_uid() {
             Ok(iter) => iter,
@@ -155,7 +175,15 @@ impl BcCamera {
         let username: String = username.into();
         let passwd: Option<String> = passwd.map(|t| t.into());
         for addr_or_uid in addr_iter {
-            if let Ok(cam) = Self::new(addr_or_uid, channel_id, &username, passwd.as_ref()).await {
+            if let Ok(cam) = Self::new(
+                addr_or_uid,
+                channel_id,
+                &username,
+                passwd.as_ref(),
+                aux_info_format,
+            )
+            .await
+            {
                 return Ok(cam);
             }
         }
@@ -185,6 +213,7 @@ impl BcCamera {
         channel_id: u8,
         username: U,
         passwd: Option<V>,
+        aux_info_format: PrintFormat,
     ) -> Result<Self> {
         let username: String = username.into();
         let passwd: Option<String> = passwd.map(|t| t.into());
@@ -307,7 +336,7 @@ impl BcCamera {
             credentials: Credentials::new(username, passwd),
         };
         me.keepalive().await?;
-        me.monitor_battery().await?;
+        me.monitor_battery(aux_info_format).await?;
         Ok(me)
     }
 

--- a/crates/core/src/bc_protocol/battery.rs
+++ b/crates/core/src/bc_protocol/battery.rs
@@ -34,7 +34,7 @@ impl BcCamera {
                 } = bc
                 {
                     for battery in battery_list.battery_info.iter() {
-                        info!(
+                        println!(
                             "==Battery==\n\
                             Charge: {}%,\n\
                             Temperature: {}°C,\n\

--- a/crates/core/src/bc_protocol/battery.rs
+++ b/crates/core/src/bc_protocol/battery.rs
@@ -1,0 +1,114 @@
+//! Handles battery related messages
+//!
+//! There are primarily two messages:
+//! - BatteryInfoList which the camera sends as part of its login info
+//! - BatteryInfo which the client can request on demand
+//!
+
+use super::{BcCamera, Result};
+use crate::{
+    bc::{model::*, xml::BatteryInfo},
+    Error,
+};
+use log::*;
+
+impl BcCamera {
+    /// Create a handller to respond to battery messages
+    /// These messages are sent by the camera on login and maybe
+    /// also on low battery events
+    pub async fn monitor_battery(&self) -> Result<()> {
+        let connection = self.get_connection();
+        connection
+            .handle_msg(MSG_ID_BATTERY_INFO_LIST, |bc| {
+                if let Bc {
+                    body:
+                        BcBody::ModernMsg(ModernMsg {
+                            payload:
+                                Some(BcPayloads::BcXml(BcXml {
+                                    battery_list: Some(battery_list),
+                                    ..
+                                })),
+                            ..
+                        }),
+                    ..
+                } = bc
+                {
+                    for battery in battery_list.battery_info.iter() {
+                        info!(
+                            "==Battery==\n\
+                            Charge: {}%,\n\
+                            Temperature: {}°C,\n\
+                            LowPower: {},\n\
+                            Adapter: {},\n\
+                            ChargeStatus: {},\n\
+                            ",
+                            battery.battery_percent,
+                            battery.temperature,
+                            if battery.low_power == 1 {
+                                "true"
+                            } else {
+                                "false"
+                            },
+                            battery.adapter_status,
+                            battery.charge_status,
+                        );
+                    }
+                }
+                None
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Requests the current battery status of the camera
+    pub async fn battery_info(&self) -> Result<BatteryInfo> {
+        let connection = self.get_connection();
+
+        let msg_num = self.new_message_num();
+        let mut sub = connection.subscribe(msg_num).await?;
+
+        let msg = Bc {
+            meta: BcMeta {
+                msg_id: MSG_ID_BATTERY_INFO,
+                channel_id: self.channel_id,
+                msg_num,
+                stream_type: 0,
+                response_code: 0,
+                class: 0x6414,
+            },
+            body: BcBody::ModernMsg(ModernMsg {
+                extension: Some(Extension {
+                    channel_id: Some(self.channel_id),
+                    ..Default::default()
+                }),
+                payload: None,
+            }),
+        };
+
+        sub.send(msg).await?;
+        let msg = sub.recv().await?;
+
+        if let Bc {
+            meta: BcMeta {
+                response_code: 200, ..
+            },
+            body:
+                BcBody::ModernMsg(ModernMsg {
+                    payload:
+                        Some(BcPayloads::BcXml(BcXml {
+                            battery_info: Some(battery_info),
+                            ..
+                        })),
+                    ..
+                }),
+        } = msg
+        {
+            Ok(battery_info)
+        } else {
+            Err(Error::UnintelligibleReply {
+                reply: std::sync::Arc::new(Box::new(msg)),
+                why: "The camera did not accept the battery info (maybe no battery) command.",
+            })
+        }
+    }
+}

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -63,6 +63,18 @@ address = "192.168.1.187:9000"
 #
 # discovery = "relay"
 
+# Certain types of camera emit status messages (such as battery levels)
+#
+# By default we hide these status messages from the user but you can instead requst that
+# they be printed to stdout using print_format
+# 
+# Valid values are:
+# - None
+# - Human
+# - Xml
+#
+# print_format = "None"
+
 
 [[cameras]]
 name = "storage shed"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use lazy_static::lazy_static;
+use neolink_core::bc_protocol::PrintFormat;
 use regex::Regex;
 use serde::Deserialize;
 use std::clone::Clone;
@@ -99,6 +100,9 @@ pub(crate) struct CameraConfig {
     #[serde(default = "default_strict")]
     /// If strict then the media stream will error in the event that the media packets are not as expected
     pub(crate) strict: bool,
+
+    #[serde(default = "default_print", alias = "print")]
+    pub(crate) print_format: PrintFormat,
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]
@@ -141,6 +145,10 @@ fn validate_mqtt_config(config: &MqttConfig) -> Result<(), ValidationError> {
 
 fn default_mqtt() -> Option<MqttConfig> {
     None
+}
+
+fn default_print() -> PrintFormat {
+    PrintFormat::None
 }
 
 fn default_discovery() -> String {

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -322,9 +322,32 @@ impl MessageHandler {
                                     "OK".to_string()
                                 }
                             }
-                            Messages::Battery => {
-                                todo!()
-                            }
+                            Messages::Battery => match self.camera.battery_info().await {
+                                Err(_) => {
+                                    error!("Failed to get battery status");
+                                    "FAIL".to_string()
+                                }
+                                Ok(battery_info) => {
+                                    let bytes_res = yaserde::ser::serialize_with_writer(
+                                        &battery_info,
+                                        vec![],
+                                        &Default::default(),
+                                    );
+                                    match bytes_res {
+                                        Ok(bytes) => match String::from_utf8(bytes) {
+                                            Ok(str) => str,
+                                            Err(_) => {
+                                                error!("Failed to encode battery status");
+                                                "FAIL".to_string()
+                                            }
+                                        },
+                                        Err(_) => {
+                                            error!("Failed to serialise battery status");
+                                            "FAIL".to_string()
+                                        }
+                                    }
+                                }
+                            },
                             Messages::Ptz(direction) => {
                                 let (bc_direction, amount) = match direction {
                                     Direction::Up(amount) => (BcDirection::Up, amount),

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -159,6 +159,7 @@ impl EventCam {
                 camera_config.channel_id,
                 &camera_config.username,
                 camera_config.password.as_ref(),
+                camera_config.print_format,
             )
             .await
             .with_context(|| {

--- a/src/rtsp/states/mod.rs
+++ b/src/rtsp/states/mod.rs
@@ -67,6 +67,7 @@ impl RtspCamera {
                 config.channel_id,
                 &config.username,
                 config.password.as_ref(),
+                config.print_format,
             )
             .await
             .with_context(|| {


### PR DESCRIPTION
This adds two battery commands.

One registers neolink camera to listen for battery messages from the camera. This is registeration is always done by default. Neolink will listen for these messages and print log messages when they are recieved. The camera appears to send them one certain events occur such as when charge status changes.

Two a command to request current battery info from the camera.