### PR TITLE
Add some copyright notices at the entry points of programs

### DIFF
--- a/dissector/baichuan.lua
+++ b/dissector/baichuan.lua
@@ -2,6 +2,20 @@
 -- Copy/symlink it into ~/.local/lib/wireshark/plugins/ and restart Wireshark; it should
 -- automatically attempt to decode TCP connections on port 9000.
 
+-- Copyright (c) the Neolink contributors
+--
+-- This program is free software: you can redistribute it and/or modify it
+-- under the terms of the GNU Affero General Public License, version 3, as
+-- published by the Free Software Foundation.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+-- FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+-- more details.
+--
+-- You should have received a copy of the GNU General Public License along with
+-- this program. If not, see <https://www.gnu.org/licenses/>.
+
 local bc_protocol = Proto("Baichuan",  "Baichuan/Reolink IP Camera Protocol")
 
 local magic_bytes = ProtoField.int32("baichuan.magic", "magic", base.DEC)

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 use structopt::{clap::AppSettings, StructOpt};
 
 /// A standards-compliant bridge to Reolink IP cameras
+///
+/// Neolink is free software released under the GNU AGPL v3.
+/// You can find its source code at https://github.com/thirtythreeforty/neolink
 #[derive(StructOpt, Debug)]
 #[structopt(
     name = "neolink",

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,19 @@
 //! It contains sub commands for running an rtsp proxy which can be used on Reolink cameras
 //! that do not nativly support RTSP.
 //!
+//! This program is free software: you can redistribute it and/or modify it under the terms of the
+//! GNU General Public License as published by the Free Software Foundation, either version 3 of
+//! the License, or (at your option) any later version.
+//!
+//! This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//! without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+//! the GNU General Public License for more details.
+//!
+//! You should have received a copy of the GNU General Public License along with this program. If
+//! not, see <https://www.gnu.org/licenses/>.
+//!
+//! Neolink source code is available online at <https://github.com/thirtythreeforty/neolink>
+//!
 use anyhow::{Context, Result};
 use env_logger::Env;
 use log::*;


### PR DESCRIPTION
The existing readme is clear about the license applying to the whole project, however to clarify a little further, and to make sure the notice conveys with copy/pasted portions (especially the dissector), add a notice to the head of each executable.  Also, make the neolink help print the license and source code link.

See #341.