### PR TITLE
Add docker run instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ branch gets it's own tag.
 ```bash
 docker pull quantumentangledandy/neolink
 
-# remove `-e "RUST_LOG=trace"` to run in production mode
+# remove `-e "RUST_LOG=debug"` to run in production mode
 docker run --name neolink --network host --restart=unless-stopped -d -e "RUST_LOG=trace" --volume=$PWD/config.toml:/etc/neolink.toml quantumentangledandy/neolink
 ```
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ branch gets it's own tag.
 
 ```bash
 docker pull quantumentangledandy/neolink
+
+# remove `-e "RUST_LOG=trace"` to run in production mode
+docker run --name neolink --network host --restart=unless-stopped -d -e "RUST_LOG=trace" --volume=$PWD/config.toml:/etc/neolink.toml quantumentangledandy/neolink
 ```
 
 ### Image


### PR DESCRIPTION
Add docker run instructions to README, use host networking to avoid explicitly mapping a bunch of ports, and trace logging to document for any users that need to troubleshoot.