### PR TITLE
Feature/cellular

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ In the `[[cameras]]` section of the toml.
 Possible values are `local`, `remote`, `map`, `relay` later values implictly
 enable prior methods.
 
+#### Cellular
+
+Cellular cameras should select `"cellular"` which only enables `map` and
+`relay` since `local` and `remote` will always fail
+
+```toml
+discovery = "cellular"
+```
+
 ### MQTT
 
 To use mqtt you will to adjust your config file as such:

--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ passed by a script for processing.
 
 [Docker](https://hub.docker.com/r/quantumentangledandy/neolink) builds are also
 provided in multiple architectures. The latest tag tracks master while each
-
 branch gets it's own tag.
 
 ```bash

--- a/crates/core/src/bc_protocol.rs
+++ b/crates/core/src/bc_protocol.rs
@@ -139,14 +139,16 @@ impl BcCamera {
                     }
                 }
             }
-            info!("{}: Trying TCP discovery", options.name);
-            for socket in sockets.drain(..) {
-                let channel_id: u8 = options.channel_id;
-                if let Ok(addr) = Discovery::check_tcp(socket, channel_id).await.map(|_| {
-                    info!("{}: TCP Discovery success at {:?}", options.name, &socket);
-                    socket
-                }) {
-                    return Ok(CameraLocation::Tcp(addr));
+            if !sockets.is_empty() {
+                info!("{}: Trying TCP discovery", options.name);
+                for socket in sockets.drain(..) {
+                    let channel_id: u8 = options.channel_id;
+                    if let Ok(addr) = Discovery::check_tcp(socket, channel_id).await.map(|_| {
+                        info!("{}: TCP Discovery success at {:?}", options.name, &socket);
+                        socket
+                    }) {
+                        return Ok(CameraLocation::Tcp(addr));
+                    }
                 }
             }
         }
@@ -176,6 +178,7 @@ impl BcCamera {
                 DiscoveryMethods::Remote => (true, true, false, false),
                 DiscoveryMethods::Map => (true, true, true, false),
                 DiscoveryMethods::Relay => (true, true, true, true),
+                DiscoveryMethods::Cellular => (false, false, true, true),
                 DiscoveryMethods::Debug => (false, false, false, true),
             };
 

--- a/crates/core/src/bc_protocol/resolution.rs
+++ b/crates/core/src/bc_protocol/resolution.rs
@@ -38,6 +38,10 @@ pub enum DiscoveryMethods {
     /// **This also enabled `Local`, `Map` and `Remote` discovery**
     #[serde(alias = "relay")]
     Relay,
+    /// Cellular camera only support relay and map, by choosing this option
+    /// only those are tried
+    #[serde(alias = "cellular")]
+    Cellular,
     #[doc(hidden)]
     #[serde(alias = "debug")]
     /// Used for debugging it is set to whatever the dev is currently testing

--- a/crates/core/src/bc_protocol/stream.rs
+++ b/crates/core/src/bc_protocol/stream.rs
@@ -91,7 +91,12 @@ impl BcCamera {
         mut buffer_size: usize,
         strict: bool,
     ) -> Result<StreamData> {
-        self.has_ability_rw("preview").await?;
+        if let Err(e) = self.has_ability_rw("preview").await {
+            if self.has_ability_ro("streamTable").await.is_err() {
+                return Err(e);
+            }
+        }
+
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
 
@@ -256,7 +261,11 @@ impl BcCamera {
 
     /// Stop a camera from sending more stream data.
     pub async fn stop_video(&self, stream: StreamKind) -> Result<()> {
-        self.has_ability_rw("preview").await?;
+        if let Err(e) = self.has_ability_rw("preview").await {
+            if self.has_ability_ro("streamTable").await.is_err() {
+                return Err(e);
+            }
+        }
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
         let mut sub_video = connection.subscribe(msg_num).await?;

--- a/crates/core/src/bcudp/xml.rs
+++ b/crates/core/src/bcudp/xml.rs
@@ -240,6 +240,17 @@ pub struct IpPort {
     pub port: u16,
 }
 
+impl std::convert::TryFrom<IpPort> for std::net::SocketAddr {
+    type Error = crate::Error;
+
+    fn try_from(src: IpPort) -> Result<Self, Self::Error> {
+        Ok(src
+            .ip
+            .parse::<std::net::IpAddr>()
+            .map(|ip| std::net::SocketAddr::new(ip, src.port))?)
+    }
+}
+
 /// C2R_C xml
 ///
 /// This is from client to the register reolink server
@@ -290,11 +301,11 @@ pub struct R2cT {
 #[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize, Clone)]
 pub struct R2cCr {
     /// Dev camera location (actual local ip)
-    pub dev: IpPort,
+    pub dev: Option<IpPort>,
     /// Dmap camera location
-    pub dmap: IpPort,
+    pub dmap: Option<IpPort>,
     /// The location of the relay
-    pub relay: IpPort,
+    pub relay: Option<IpPort>,
     /// The nat type. Known values `"NULL"`
     pub nat: String,
     /// The camera SID

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -61,6 +61,8 @@ address = "192.168.1.187:9000"
 # "remote" # Register our local ip address with reolink but only permit same network connections (useful if broadcast is not possible)
 # "local" # Do not contact reolink servers at all. Rely soley on local UDP broadcast based discovery
 #
+# "cellular" # Cellular camera only support Relay and Map to speed up connecting to them this option will skip the local/remote
+#
 # discovery = "relay"
 
 # Certain types of camera emit status messages (such as battery levels)


### PR DESCRIPTION
Fixes the discovery to handle the case when no local device ip is available

Also adds the discovery method `cellular` which should be added to the `[[cameras]]` block on the config

```toml
[[cameras]]
name = "SOMETHING"
uid = "SOMETHING"
username = "admin"
password = "SOMETHING"
discovery = "cellular"
```

This should get it to work on cellular cameras.

p.s. The default user is `admin` so if your reolink app dosen't prompt you for or allow you to create a user then that will be the username to use