### PR TITLE
Add PTZ presets and PTZ command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Control messages:
 - `/control/reboot` Reboot the camera
 - `/control/ptz [up|down|left|right|in|out]` (amount) Control the PTZ
   movements, amount defaults to 32.0
+- `/control/preset [id]` Move to PTZ preset `id`
 - `/control/pir [on|off]`
 
 Status Messages:

--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -19,6 +19,8 @@ pub const MSG_ID_TALKABILITY: u32 = 10;
 pub const MSG_ID_TALKRESET: u32 = 11;
 /// PtzControl messages have this ID
 pub const MSG_ID_PTZ_CONTROL: u32 = 18;
+/// PTZ goto preset position
+pub const MSG_ID_PTZ_CONTROL_PRESET: u32 = 19;
 /// Reboot messages have this ID
 pub const MSG_ID_REBOOT: u32 = 23;
 /// Request motion detection messages
@@ -35,6 +37,8 @@ pub const MSG_ID_GET_GENERAL: u32 = 104;
 pub const MSG_ID_ABILITY_INFO: u32 = 151;
 /// Setting general system info (clock mostly) messages have this ID
 pub const MSG_ID_SET_GENERAL: u32 = 105;
+/// Get the available PTZ position presets
+pub const MSG_ID_GET_PTZ_PRESET: u32 = 190;
 /// Will send the talk config for talk back data to follow this msg
 pub const MSG_ID_TALKCONFIG: u32 = 201;
 /// Used to send talk back binary data

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -76,6 +76,9 @@ pub struct BcXml {
     /// Sent to move the camera
     #[yaserde(rename = "PtzControl")]
     pub ptz_control: Option<PtzControl>,
+    /// Sent or received for the PTZ preset functionality
+    #[yaserde(rename = "PtzPreset")]
+    pub ptz_preset: Option<PtzPreset>,
     /// Recieved on login/low battery events
     #[yaserde(rename = "BatteryList")]
     pub battery_list: Option<BatteryList>,
@@ -519,8 +522,41 @@ pub struct PtzControl {
     pub channel_id: u8,
     /// The amount of movement to perform
     pub speed: f32,
-    /// The direction to transverse. Known directions: "right"
+    /// The direction to transverse. Known values are `"left"`, `"right"`, `"up"`, `"down"`,
+    /// `"leftUp"`, `"leftDown"`, `"rightUp"`, `"rightDown"` and `"stop"`
     pub command: String,
+}
+
+/// An XML that describes a list of available PTZ presets
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct PtzPreset {
+    /// XML Version
+    #[yaserde(attribute)]
+    pub version: String,
+    /// The channel ID. Usually zero unless from an NVR
+    #[yaserde(rename = "channelId")]
+    pub channel_id: u8,
+    /// List of presets
+    #[yaserde(rename = "presetList")]
+    pub preset_list: Option<PresetList>,
+}
+
+/// A preset list
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct PresetList {
+    /// List of Presets
+    pub preset: Vec<Preset>,
+}
+
+/// A preset. Either contains the ID and the name or the ID and the command
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct Preset {
+    /// The ID of the preset
+    pub id: i8,
+    /// The preset name
+    pub name: Option<String>,
+    /// Command: Known values: `"toPos"` and `"setPos"`
+    pub command: Option<String>,
 }
 
 /// A list of battery infos. This message is sent from the camera as

--- a/dissector/baichuan.lua
+++ b/dissector/baichuan.lua
@@ -88,6 +88,7 @@ local message_types = {
   [15]="<FileInfoList>",
   [16]="<FileInfoList>",
   [18]="<PtzControl>",
+  [19]="<PtzPreset>",
   [23]="Reboot",
   [25]="<VideoInput> (write)",
   [26]="<VideoInput>", -- <InputAdvanceCfg>

--- a/dissector/messages.md
+++ b/dissector/messages.md
@@ -354,6 +354,10 @@ Message have zero to two payloads.
     </PtzControl>
     </body>
     ```
+    
+    - **Notes** : The known movement commands are `"left"`, `"right"`, `"up"`, `"down"`, `"leftUp"`,
+                  `"leftDown"`, `"rightUp"`, `"rightDown"` and `"stop"` although the diagonal movement
+                  does not seem to work.
 
   - Camera
 
@@ -362,6 +366,45 @@ Message have zero to two payloads.
         |    Magic     |  Message ID  | Message Length | Encryption Offset |    Status Code    | Message Class | Payload Offset |
         |--------------|--------------|----------------|-------------------|-------------------|---------------|---------------|
         | 0a bc de f0  | 00 00 00 12  |  00 00 00 00   |    1e 00 00 00    |       c8 00       |     00 00     |  00 00 00 00  |
+
+- 19: `<PtzPreset>`
+
+  - Client
+
+    - Header
+
+        |    Magic     | Message ID  | Message Length | Encryption Offset |    Status Code    | Message Class | Payload Offset |
+        |--------------|-------------|----------------|-------------------|-------------------|---------------|---------------|
+        | 0a bc de f0  | 00 00 00 13 | 00 00 01 44    |    1e 00 00 00    |       00 00       |     64 14     |  00 00 00 00  |
+
+    - Payload
+
+    ```xml
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <body>
+    <PtzPreset version="1.1">
+    <channelId>0</channelId>
+    <presetList>
+    <preset>
+    <id>0</id>
+    <command>setPos</command>
+    <name>Test</name>
+    </preset>
+    </presetList>
+    </PtzPreset>
+    </body>
+    ```
+    
+    - **Notes** : The known values for command are `"setPos"` and `"toPos"`
+
+  - Camera
+
+    - Header
+
+        |    Magic     | Message ID  | Message Length | Encryption Offset |    Status Code    | Message Class | Payload Offset |
+        |--------------|-------------|----------------|-------------------|-------------------|---------------|---------------|
+        | 0a bc de f0  | 00 00 00 13 |  00 00 00 00   |    1e 00 00 00    |       c8 00       |     00 00     |  00 00 00 00  |
+
 
 - 23: `Reboot`
 
@@ -1987,7 +2030,12 @@ Message have zero to two payloads.
     <body>
     <PtzPreset version="1.1">
     <channelId>0</channelId>
-    <presetList />
+    <presetList>
+    <preset>
+    <id>0</id>
+    <name>Test</name>
+    </preset>
+    </presetList>
     </PtzPreset>
     </body>
     ```

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -21,6 +21,7 @@ pub enum Command {
     StatusLight(super::statusled::Opt),
     Reboot(super::reboot::Opt),
     Pir(super::pir::Opt),
+    Ptz(super::ptz::Opt),
     Talk(super::talk::Opt),
     Mqtt(super::mqtt::Opt),
     Image(super::image::Opt),

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod config;
 mod image;
 mod mqtt;
 mod pir;
+mod ptz;
 mod reboot;
 mod rtsp;
 mod statusled;
@@ -101,6 +102,9 @@ async fn main() -> Result<()> {
         }
         Some(Command::Pir(opts)) => {
             pir::main(opts, config).await?;
+        }
+        Some(Command::Ptz(opts)) => {
+            ptz::main(opts, config).await?;
         }
         Some(Command::Talk(opts)) => {
             talk::main(opts, config).await?;

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -511,27 +511,23 @@ impl<'a> MessageHandler<'a> {
                             }
                         }
                         Messages::Ptz(direction) => {
-                            let (bc_direction, amount, seconds) = match direction {
-                                Direction::Up(amount, seconds) => {
-                                    (BcDirection::Up, amount, seconds)
+                            let (bc_direction, speed, seconds) = match direction {
+                                Direction::Up(speed, seconds) => (BcDirection::Up, speed, seconds),
+                                Direction::Down(speed, seconds) => {
+                                    (BcDirection::Down, speed, seconds)
                                 }
-                                Direction::Down(amount, seconds) => {
-                                    (BcDirection::Down, amount, seconds)
+                                Direction::Left(speed, seconds) => {
+                                    (BcDirection::Left, speed, seconds)
                                 }
-                                Direction::Left(amount, seconds) => {
-                                    (BcDirection::Left, amount, seconds)
+                                Direction::Right(speed, seconds) => {
+                                    (BcDirection::Right, speed, seconds)
                                 }
-                                Direction::Right(amount, seconds) => {
-                                    (BcDirection::Right, amount, seconds)
-                                }
-                                Direction::In(amount, seconds) => {
-                                    (BcDirection::In, amount, seconds)
-                                }
-                                Direction::Out(amount, seconds) => {
-                                    (BcDirection::Out, amount, seconds)
+                                Direction::In(speed, seconds) => (BcDirection::In, speed, seconds),
+                                Direction::Out(speed, seconds) => {
+                                    (BcDirection::Out, speed, seconds)
                                 }
                             };
-                            if let Err(e) = self.camera.send_ptz(bc_direction, amount).await {
+                            if let Err(e) = self.camera.send_ptz(bc_direction, speed).await {
                                 error = Some(format!("Failed to send PTZ: {:?}", e));
                                 "FAIL".to_string()
                             } else {
@@ -539,9 +535,7 @@ impl<'a> MessageHandler<'a> {
                                 sleep(Duration::from_secs_f32(seconds)).await;
 
                                 // note that amount is not used in the stop command
-                                if let Err(e) =
-                                    self.camera.send_ptz(BcDirection::Stop, amount).await
-                                {
+                                if let Err(e) = self.camera.send_ptz(BcDirection::Stop, 0.0).await {
                                     error = Some(format!("Failed to send PTZ: {:?}", e));
                                     "FAIL".to_string()
                                 } else {

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -30,6 +30,7 @@ pub(crate) enum Messages {
     PIROff,
     PIRQuery,
     Ptz(Direction),
+    Preset(i8),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -447,6 +448,14 @@ impl<'a> MessageHandler<'a> {
                                 } else {
                                     "OK".to_string()
                                 }
+                            }
+                        }
+                        Messages::Preset(id) => {
+                            if let Err(e) = self.camera.set_ptz_preset(id, None).await {
+                                error = Some(format!("Failed to send PTZ preset: {:?}", e));
+                                "FAIL".to_string()
+                            } else {
+                                "OK".to_string()
                             }
                         }
                         _ => "UNKNOWN COMMAND".to_string(),

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -333,9 +333,10 @@ async fn handle_mqtt_message(
             let mut words = lowercase_message.split_whitespace();
             if let Some(direction_txt) = words.next() {
                 // Target amount to move
+                let speed = 32f32;
                 let amount = words.next().unwrap_or("32.0");
                 if let Ok(amount) = amount.parse::<f32>() {
-                    let seconds = amount / 32f32;
+                    let seconds = amount / speed;
                     // range checking on seconds so that you can't sleep for 3.4E+38 seconds
                     match seconds {
                         x if (0.0..10.0).contains(&x) => seconds,
@@ -346,12 +347,12 @@ async fn handle_mqtt_message(
                     };
 
                     let direction = match direction_txt {
-                        "up" => Direction::Up(amount, seconds),
-                        "down" => Direction::Down(amount, seconds),
-                        "left" => Direction::Left(amount, seconds),
-                        "right" => Direction::Right(amount, seconds),
-                        "in" => Direction::In(amount, seconds),
-                        "out" => Direction::Out(amount, seconds),
+                        "up" => Direction::Up(speed, seconds),
+                        "down" => Direction::Down(speed, seconds),
+                        "left" => Direction::Left(speed, seconds),
+                        "right" => Direction::Right(speed, seconds),
+                        "in" => Direction::In(speed, seconds),
+                        "out" => Direction::Out(speed, seconds),
                         _ => {
                             error!("Unrecognized PTZ direction \"{}\"", direction_txt);
                             return Ok(());

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -14,6 +14,7 @@
 /// - `/control/ir [on|off|auto]` Turn IR lights on/off or automatically via light detection
 /// - `/control/reboot` Reboot the camera
 /// - `/control/ptz` [up|down|left|right|in|out] (amount) Control the PTZ movements, amount defaults to 32.0
+/// - `/control/preset` [id] Move the camera to a known preset
 ///
 /// Status Messages:
 ///
@@ -323,6 +324,21 @@ async fn handle_mqtt_message(
                 }
             } else {
                 error!("No PTZ Direction given. Please add up/down/left/right/in/out");
+            }
+        }
+        MqttReplyRef {
+            topic: "control/preset",
+            message,
+        } => {
+            if let Ok(id) = message.parse::<i8>() {
+                reply = Some(
+                    event_cam_sender
+                        .send_message_with_reply(Messages::Preset(id))
+                        .await
+                        .with_context(|| "Failed to send PTZ preset")?,
+                );
+            } else {
+                error!("PTZ preset was not a valid number");
             }
         }
         MqttReplyRef {

--- a/src/ptz/cmdline.rs
+++ b/src/ptz/cmdline.rs
@@ -1,0 +1,40 @@
+use clap::Parser;
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum CmdDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+    In,
+    Out,
+    Stop,
+}
+
+/// The ptz command will control the positioning of the camera
+#[derive(Parser, Debug)]
+pub struct Opt {
+    /// The name of the camera to change the lights of. Must be a name in the config
+    pub camera: String,
+
+    #[command(subcommand)]
+    pub cmd: PtzCommand,
+}
+
+#[derive(Parser, Debug)]
+pub enum PtzCommand {
+    /// Gets the available presets on the camera, moves the camera to a given preset ID or saves
+    /// the current position as a preset with name and ID.
+    Preset {
+        preset_id: Option<i8>,
+        name: Option<String>,
+    },
+    /// Performs a movement in the given direction
+    Control {
+        /// The time in milliseconds to move
+        duration: u32,
+        /// The direction command
+        #[clap(value_enum)]
+        command: CmdDirection,
+    },
+}

--- a/src/ptz/cmdline.rs
+++ b/src/ptz/cmdline.rs
@@ -31,10 +31,12 @@ pub enum PtzCommand {
     },
     /// Performs a movement in the given direction
     Control {
-        /// The time in milliseconds to move
-        duration: u32,
+        /// The amount to move
+        amount: u32,
         /// The direction command
         #[clap(value_enum)]
         command: CmdDirection,
+        /// The speed to move at
+        speed: Option<u32>,
     },
 }

--- a/src/ptz/mod.rs
+++ b/src/ptz/mod.rs
@@ -1,0 +1,79 @@
+///
+/// # Neolink PTZ Control
+///
+/// This module handles the controls of the PTZ commands
+///
+/// # Usage
+///
+/// ```bash
+/// # Rotate left for 300 milliseconds
+/// neolink status-light --config=config.toml CameraName control 300 left
+/// # Print the list of preset positions
+/// neolink status-light --config=config.toml CameraName preset
+/// # Move the camera to preset ID 0
+/// neolink status-light --config=config.toml CameraName preset 0
+/// # Save the current position as preset ID 0 with name PresetName
+/// neolink status-light --config=config.toml CameraName preset 0 PresetName
+/// ```
+///
+use anyhow::{Context, Result};
+use std::thread::sleep;
+use std::time::Duration;
+
+mod cmdline;
+
+use super::config::Config;
+use crate::ptz::cmdline::CmdDirection;
+use crate::ptz::cmdline::PtzCommand;
+use crate::utils::find_and_connect;
+pub(crate) use cmdline::Opt;
+use neolink_core::bc_protocol::Direction;
+
+/// Entry point for the ptz subcommand
+///
+/// Opt is the command line options
+pub(crate) async fn main(opt: Opt, config: Config) -> Result<()> {
+    let camera = find_and_connect(&config, &opt.camera).await?;
+
+    match opt.cmd {
+        PtzCommand::Preset { preset_id, name } => {
+            if preset_id.is_some() {
+                camera
+                    .set_ptz_preset(preset_id.unwrap(), name)
+                    .await
+                    .context("Unable to set PTZ preset")
+                    .expect("TODO: panic message");
+            } else {
+                let preset_list = camera
+                    .get_ptz_preset()
+                    .await
+                    .context("Unable to get PTZ presets")?;
+                println!("Available presets:\nID Name");
+                for preset in preset_list.preset_list.unwrap().preset {
+                    println!("{:<2} {}", preset.id, preset.name.unwrap());
+                }
+            }
+        }
+        PtzCommand::Control { duration, command } => {
+            let direction = match command {
+                CmdDirection::Left => Direction::Left,
+                CmdDirection::Right => Direction::Right,
+                CmdDirection::Up => Direction::Up,
+                CmdDirection::Down => Direction::Down,
+                CmdDirection::In => Direction::In,
+                CmdDirection::Out => Direction::Out,
+                CmdDirection::Stop => Direction::Stop,
+            };
+            camera
+                .send_ptz(direction, 32_f32)
+                .await
+                .context("Unable to execute PTZ move command")?;
+            sleep(Duration::from_millis(duration as u64));
+            camera
+                .send_ptz(Direction::Stop, 0_f32)
+                .await
+                .context("Unable to execute PTZ move command")?;
+        }
+    };
+    Ok(())
+}

--- a/src/ptz/mod.rs
+++ b/src/ptz/mod.rs
@@ -17,8 +17,7 @@
 /// ```
 ///
 use anyhow::{Context, Result};
-use std::thread::sleep;
-use std::time::Duration;
+use tokio::time::{sleep, Duration};
 
 mod cmdline;
 
@@ -68,7 +67,7 @@ pub(crate) async fn main(opt: Opt, config: Config) -> Result<()> {
                 .send_ptz(direction, 32_f32)
                 .await
                 .context("Unable to execute PTZ move command")?;
-            sleep(Duration::from_millis(duration as u64));
+            sleep(Duration::from_millis(duration as u64)).await;
             camera
                 .send_ptz(Direction::Stop, 0_f32)
                 .await


### PR DESCRIPTION
As mentioned by @QuantumEntangledAndy in https://github.com/thirtythreeforty/neolink/pull/356 the main `neolink` development moved to this repo where part of the PTZ functionality is already available.

I rebased my changes to this repo to add the ptz preset functionality and commandline here. If these changes are okay I will try to add the preset functionality to mqtt as well.