### PR TITLE
Feature/optional MQTT discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,8 +1427,10 @@ dependencies = [
  "gstreamer-app",
  "gstreamer-rtsp",
  "gstreamer-rtsp-server",
+ "heck",
  "is_sorted",
  "itertools",
+ "json",
  "lazy_static",
  "log",
  "neolink_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,12 +1267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,13 +1424,13 @@ dependencies = [
  "heck",
  "is_sorted",
  "itertools",
- "json",
  "lazy_static",
  "log",
  "neolink_core",
  "regex",
  "rumqttc",
  "serde",
+ "serde_json",
  "time",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"
@@ -1411,6 +1411,7 @@ name = "neolink"
 version = "0.5.12"
 dependencies = [
  "anyhow",
+ "base64 0.21.2",
  "byte-slice-cast",
  "clap",
  "console-subscriber",
@@ -1919,7 +1920,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ gstreamer = "0.20.3"
 gstreamer-app = "0.20.0"
 gstreamer-rtsp = "0.20.0"
 gstreamer-rtsp-server = { version = "0.20.3", features = ["v1_16"] }
+heck = "0.4.1"
 is_sorted = "0.1.1"
 itertools = "0.10.5"
+json = "0.12.4"
 lazy_static = "1.4.0"
 log = { version = "0.4.17", features = [ "release_max_level_debug" ] }
 neolink_core = { path = "crates/core", version = "0.5.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 
 [dependencies]
 anyhow = "1.0.70"
+base64 = "0.21.2"
 byte-slice-cast = "1.2.2"
 clap = { version = "4.2.2", features = ["derive", "cargo"] }
 console-subscriber = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ gstreamer-rtsp-server = { version = "0.20.3", features = ["v1_16"] }
 heck = "0.4.1"
 is_sorted = "0.1.1"
 itertools = "0.10.5"
-json = "0.12.4"
 lazy_static = "1.4.0"
 log = { version = "0.4.17", features = [ "release_max_level_debug" ] }
 neolink_core = { path = "crates/core", version = "0.5.12" }
 regex = "1.7.3"
 rumqttc = "0.20.0"
 serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.96"
 time = "0.3.20"
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros", "io-util", "tracing"] }
 tokio-stream = "0.1.12"

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Status Messages:
   of the battery status
 - `/status/pir` Sent in reply to a `/query/pir` an XML encoded version of the
   pir status
+- `/status/motion` Contains the motion detection alarm status. `on` for motion and `off` for still
 
 Query Messages:
 

--- a/README.md
+++ b/README.md
@@ -209,12 +209,35 @@ Status Messages:
 - `/status/motion` Contains the motion detection alarm status. `on` for motion and `off` for still
 - `/status/ptz/preset` Sent in reply to a `/query/ptz/preset` an XML encoded version of the
   PTZ presets
+- `/status/preview` a base64 encoded camera image updated every 0.5s
 
 Query Messages:
 
 - `/query/battery` Request that the camera reports its battery level
 - `/query/pir` Request that the camera reports its pir status
 - `/query/ptz/preset` Request that the camera reports its PTZ presets
+
+### MQTT Disable Features
+
+Certain features like preview and motion detection may not be desired
+you can disable them by them with the following config options. 
+Disabling these may help to conserve battery
+
+```toml
+enable_motion = false  # motion detection
+                       # (limited battery drain since it
+                       # is a passive listening connection)
+
+enable_pings = false   # keep alive pings that keep the camera connected
+
+enable_light = false   # flood lights only avaliable on some camera
+                       # (limited battery drain since it
+                       # is a passive listening connection)
+
+enable_battery = false # battery updates in `/status/battery_level`
+
+enable_preview = false # preview image in `/status/preview`
+```
 
 #### MQTT Discovery
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ Query Messages:
 - `/query/battery` Request that the camera reports its battery level
 - `/query/pir` Request that the camera reports its pir status
 
+#### MQTT Discovery
+
+[MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) is partially supported. 
+Currently, discovery is opt-in and camera features must be manually specified.
+
+```toml
+[cameras.mqtt]
+  # <see above>
+  [cameras.mqtt.discovery]
+  topic = "homeassistant"
+  features = ["floodlight"]
+```
+
+See the sample config file for more details.
+
 ### Pause
 
 To use the pause feature you will need to adjust your config file as such:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Cellular cameras should select `"cellular"` which only enables `map` and
 discovery = "cellular"
 ```
 
+See the sample config file for more details.
+
 ### MQTT
 
 To use mqtt you will to adjust your config file as such:
@@ -222,7 +224,16 @@ Currently, discovery is opt-in and camera features must be manually specified.
   features = ["floodlight"]
 ```
 
-See the sample config file for more details.
+Avaliable features are:
+
+- `floodlight`: This adds a light control to home assistant
+- `camera`: This adds a camera preview to home assistant. It is only updated every 0.5s and cannot be much more than that since it is updated over mqtt not over RTSP
+- `led`: This adds a switch to chage the LED status light on/off to home assistant
+- `ir`: This adds a selection switch to chage the IR light on/off/auto to home assistant
+- `motion`: This adds a motion detection binary sensor to home assistant
+- `reboot`: This adds a reboot button  to home assistant
+- `pt`: This adds a selection of buttons to control the pan and tilt of the camera
+
 
 ### Pause
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Status Messages:
 - `/status disconnected` Sent when the camera goes offline
 - `/status/battery` Sent in reply to a `/query/battery` an XML encoded version
   of the battery status
+- `/status/battery_level` A simple % value of current battery level
 - `/status/pir` Sent in reply to a `/query/pir` an XML encoded version of the
   pir status
 - `/status/motion` Contains the motion detection alarm status. `on` for motion and `off` for still
@@ -233,6 +234,7 @@ Avaliable features are:
 - `motion`: This adds a motion detection binary sensor to home assistant
 - `reboot`: This adds a reboot button  to home assistant
 - `pt`: This adds a selection of buttons to control the pan and tilt of the camera
+- `battery`: This adds a battery level sensor to home assistant
 
 
 ### Pause

--- a/crates/core/src/bc/de.rs
+++ b/crates/core/src/bc/de.rs
@@ -197,8 +197,10 @@ fn bc_modern_msg<'a>(
 }
 
 fn bc_header(buf: &[u8]) -> IResult<&[u8], BcHeader> {
-    let (buf, _magic) =
-        error_context("Magic invalid", verify(le_u32, |x| *x == MAGIC_HEADER || *x == MAGIC_HEADER_REV))(buf)?;
+    let (buf, _magic) = error_context(
+        "Magic invalid",
+        verify(le_u32, |x| *x == MAGIC_HEADER || *x == MAGIC_HEADER_REV),
+    )(buf)?;
     let (buf, msg_id) = error_context("MsgID missing", le_u32)(buf)?;
     let (buf, body_len) = error_context("BodyLen missing", le_u32)(buf)?;
     let (buf, channel_id) = error_context("ChannelID missing", le_u8)(buf)?;

--- a/crates/core/src/bc/de.rs
+++ b/crates/core/src/bc/de.rs
@@ -198,7 +198,7 @@ fn bc_modern_msg<'a>(
 
 fn bc_header(buf: &[u8]) -> IResult<&[u8], BcHeader> {
     let (buf, _magic) =
-        error_context("Magic invalid", verify(le_u32, |x| *x == MAGIC_HEADER))(buf)?;
+        error_context("Magic invalid", verify(le_u32, |x| *x == MAGIC_HEADER || *x == MAGIC_HEADER_REV))(buf)?;
     let (buf, msg_id) = error_context("MsgID missing", le_u32)(buf)?;
     let (buf, body_len) = error_context("BodyLen missing", le_u32)(buf)?;
     let (buf, channel_id) = error_context("ChannelID missing", le_u8)(buf)?;

--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -3,7 +3,11 @@ use crate::Credentials;
 pub use super::xml::{BcPayloads, BcXml, Extension};
 use std::collections::HashSet;
 
-pub(super) const MAGIC_HEADER: u32 = 0xabcdef0;
+pub(super) const MAGIC_HEADER: u32 = 0x0abcdef0;
+/// Sometimes will get the BE magic header even though all other numbers are LE?
+/// Seems to happens with certain messages like snap that produce jpegs, so perhaps it
+/// it is meant to be a hint as to the endianess of the binary payload
+pub(super) const MAGIC_HEADER_REV: u32 = 0x0fedcba0;
 
 /// Login messages have this ID
 pub const MSG_ID_LOGIN: u32 = 1;

--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -33,6 +33,8 @@ pub const MSG_ID_VERSION: u32 = 80;
 pub const MSG_ID_PING: u32 = 93;
 /// General system info messages have this ID
 pub const MSG_ID_GET_GENERAL: u32 = 104;
+/// Snapshot to get a jpeg image
+pub const MSG_ID_SNAP: u32 = 109;
 /// Used to get the abilities of a user
 pub const MSG_ID_ABILITY_INFO: u32 = 151;
 /// Setting general system info (clock mostly) messages have this ID

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -97,6 +97,9 @@ pub struct BcXml {
     /// Recieved on request for a link type
     #[yaserde(rename = "LinkType")]
     pub link_type: Option<LinkType>,
+    /// Recieved AND send for the snap message
+    #[yaserde(rename = "Snap")]
+    pub snap: Option<Snap>,
 }
 
 impl BcXml {
@@ -700,7 +703,37 @@ pub struct AbilityInfoSubModule {
 pub struct LinkType {
     #[yaserde(rename = "type")]
     /// Type of connection known values `"LAN"`
-    link_type: String,
+    pub link_type: String,
+}
+
+/// The Link Type contains the type of connection present
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct Snap {
+    #[yaserde(rename = "channelId")]
+    /// The channel id to get the snapshot from
+    pub channel_id: u8,
+    /// Unknown, observed values: 0
+    /// value is only set on request
+    #[yaserde(rename = "logicChannel")]
+    pub logic_channel: Option<u8>,
+    /// Time of snapshot, zero when requesting
+    pub time: u32,
+    /// Request a full frame, observed values: 0
+    /// value is only set on request
+    #[yaserde(rename = "fullFrame")]
+    pub full_frame: Option<u32>,
+    /// Stream name, observed values: `main`, `sub`
+    /// value is only set on request
+    #[yaserde(rename = "streamType")]
+    pub stream_type: Option<String>,
+    /// File name, usually of the form `01_20230518140240.jpg`
+    /// value is only set on recieve
+    #[yaserde(rename = "fileName")]
+    pub file_name: Option<String>,
+    /// Size in bytes of the picture
+    /// value is only set on recieve
+    #[yaserde(rename = "pictureSize")]
+    pub picture_size: Option<u32>,
 }
 
 /// Convience function to return the xml version used throughout the library

--- a/crates/core/src/bc_protocol.rs
+++ b/crates/core/src/bc_protocol.rs
@@ -27,6 +27,7 @@ mod pirstate;
 mod ptz;
 mod reboot;
 mod resolution;
+mod snap;
 mod stream;
 mod talk;
 mod time;

--- a/crates/core/src/bc_protocol/abilityinfo.rs
+++ b/crates/core/src/bc_protocol/abilityinfo.rs
@@ -7,7 +7,7 @@ impl BcCamera {
     pub async fn get_abilityinfo(&self) -> Result<AbilityInfo> {
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_get = connection.subscribe(msg_num).await?;
+        let mut sub_get = connection.subscribe(MSG_ID_ABILITY_INFO, msg_num).await?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_ABILITY_INFO,

--- a/crates/core/src/bc_protocol/battery.rs
+++ b/crates/core/src/bc_protocol/battery.rs
@@ -83,7 +83,7 @@ impl BcCamera {
         let connection = self.get_connection();
 
         let msg_num = self.new_message_num();
-        let mut sub = connection.subscribe(msg_num).await?;
+        let mut sub = connection.subscribe(MSG_ID_BATTERY_INFO, msg_num).await?;
 
         let msg = Bc {
             meta: BcMeta {

--- a/crates/core/src/bc_protocol/connection/bcconn.rs
+++ b/crates/core/src/bc_protocol/connection/bcconn.rs
@@ -18,8 +18,8 @@ type MsgHandler = dyn 'static + Send + Sync + for<'a> Fn(&'a Bc) -> BoxFuture<'a
 
 #[derive(Default)]
 struct Subscriber {
-    /// Subscribers based on their Num
-    num: BTreeMap<u16, Sender<Result<Bc>>>,
+    /// Subscribers based on their ID and their num
+    num: BTreeMap<u32, BTreeMap<Option<u16>, Sender<Result<Bc>>>>,
     /// Subscribers based on their ID
     id: BTreeMap<u32, Arc<MsgHandler>>,
 }
@@ -85,12 +85,12 @@ impl BcConnection {
         Ok(())
     }
 
-    pub async fn subscribe(&self, msg_num: u16) -> Result<BcSubscription> {
+    pub async fn subscribe(&self, msg_id: u32, msg_num: u16) -> Result<BcSubscription> {
         let (tx, rx) = channel(100);
         self.poll_commander
-            .send(PollCommand::AddSubscriber(msg_num, tx))
+            .send(PollCommand::AddSubscriber(msg_id, Some(msg_num), tx))
             .await?;
-        Ok(BcSubscription::new(rx, msg_num as u32, self))
+        Ok(BcSubscription::new(rx, Some(msg_num as u32), self))
     }
 
     /// Some messages are initiated by the camera. This creates a handler for them
@@ -113,6 +113,21 @@ impl BcConnection {
             .send(PollCommand::RemoveHandler(msg_id))
             .await?;
         Ok(())
+    }
+
+    /// Some times we want to wait for a reply on a new message ID
+    /// to do this we wait for the next packet with a certain ID
+    /// grab it's message ID and then subscribe to that ID
+    ///
+    /// The command Snap that grabs a jpeg payload is an example of this
+    ///
+    /// This function creates a temporary handle to grab this single message
+    pub async fn subscribe_to_id(&self, msg_id: u32) -> Result<BcSubscription> {
+        let (tx, rx) = channel(100);
+        self.poll_commander
+            .send(PollCommand::AddSubscriber(msg_id, None, tx))
+            .await?;
+        Ok(BcSubscription::new(rx, None, self))
     }
 
     pub(crate) async fn join(&self) -> Result<()> {
@@ -138,7 +153,7 @@ enum PollCommand {
     Bc(Box<Result<Bc>>),
     AddHandler(u32, Arc<MsgHandler>),
     RemoveHandler(u32),
-    AddSubscriber(u16, Sender<Result<Bc>>),
+    AddSubscriber(u32, Option<u16>, Sender<Result<Bc>>),
 }
 
 struct Poller {
@@ -152,66 +167,79 @@ impl Poller {
         while let Some(command) = self.reciever.next().await {
             yield_now().await;
             match command {
-                PollCommand::Bc(boxed_response) => match *boxed_response {
-                    Ok(response) => {
-                        let msg_num = response.meta.msg_num;
-                        let msg_id = response.meta.msg_id;
+                PollCommand::Bc(boxed_response) => {
+                    match *boxed_response {
+                        Ok(response) => {
+                            let msg_num = response.meta.msg_num;
+                            let msg_id = response.meta.msg_id;
 
-                        let mut remove_it_num = false;
-                        match (
-                            self.subscribers.id.get(&msg_id),
-                            self.subscribers.num.get(&msg_num),
-                        ) {
-                            (Some(occ), _) => {
-                                if let Some(reply) = occ(&response).await {
-                                    assert!(reply.meta.msg_num == response.meta.msg_num);
-                                    self.sink.send(Ok(reply)).await?;
+                            match (
+                                self.subscribers.id.get(&msg_id),
+                                self.subscribers.num.get_mut(&msg_id),
+                            ) {
+                                (Some(occ), _) => {
+                                    if let Some(reply) = occ(&response).await {
+                                        assert!(reply.meta.msg_num == response.meta.msg_num);
+                                        self.sink.send(Ok(reply)).await?;
+                                    }
                                 }
-                            }
-                            (None, Some(occ)) => {
-                                if occ.capacity() == 0 {
-                                    warn!("Reaching limit of channel");
-                                    warn!(
-                                        "Remaining: {} of {} message space for {} (ID: {})",
-                                        occ.capacity(),
-                                        occ.max_capacity(),
-                                        &msg_num,
-                                        &msg_id
+                                (None, Some(occ)) => {
+                                    let sender =
+                                        if let Some(sender) = occ.get(&Some(msg_num)).cloned() {
+                                            Some(sender)
+                                        } else if let Some(sender) = occ.get(&None).cloned() {
+                                            // Upgrade a None to a known MsgID
+                                            occ.remove(&None);
+                                            occ.insert(Some(msg_num), sender.clone());
+                                            Some(sender)
+                                        } else {
+                                            None
+                                        };
+                                    if let Some(sender) = sender {
+                                        if sender.capacity() == 0 {
+                                            warn!("Reaching limit of channel");
+                                            warn!(
+                                                "Remaining: {} of {} message space for {} (ID: {})",
+                                                sender.capacity(),
+                                                sender.max_capacity(),
+                                                &msg_num,
+                                                &msg_id
+                                            );
+                                        } else {
+                                            trace!(
+                                                "Remaining: {} of {} message space for {} (ID: {})",
+                                                sender.capacity(),
+                                                sender.max_capacity(),
+                                                &msg_num,
+                                                &msg_id
+                                            );
+                                        }
+                                        if sender.send(Ok(response)).await.is_err() {
+                                            occ.remove(&Some(msg_num));
+                                        }
+                                    }
+                                }
+                                (None, None) => {
+                                    debug!(
+                                        "Ignoring uninteresting message id {} (number: {})",
+                                        msg_id, msg_num
                                     );
-                                } else {
-                                    trace!(
-                                        "Remaining: {} of {} message space for {} (ID: {})",
-                                        occ.capacity(),
-                                        occ.max_capacity(),
-                                        &msg_num,
-                                        &msg_id
-                                    );
+                                    trace!("Contents: {:?}", response);
                                 }
-                                if occ.send(Ok(response)).await.is_err() {
-                                    remove_it_num = true;
-                                }
-                            }
-                            (None, None) => {
-                                debug!(
-                                    "Ignoring uninteresting message id {} (number: {})",
-                                    msg_id, msg_num
-                                );
-                                trace!("Contents: {:?}", response);
                             }
                         }
-                        if remove_it_num {
-                            self.subscribers.num.remove(&msg_num);
+                        Err(e) => {
+                            for sub in self.subscribers.num.values() {
+                                for sender in sub.values() {
+                                    let _ = sender.send(Err(e.clone())).await;
+                                }
+                            }
+                            self.subscribers.num.clear();
+                            self.subscribers.id.clear();
+                            return Err(e);
                         }
                     }
-                    Err(e) => {
-                        for sub in self.subscribers.num.values() {
-                            let _ = sub.send(Err(e.clone())).await;
-                        }
-                        self.subscribers.num.clear();
-                        self.subscribers.id.clear();
-                        return Err(e);
-                    }
-                },
+                }
                 PollCommand::AddHandler(msg_id, handler) => {
                     match self.subscribers.id.entry(msg_id) {
                         Entry::Vacant(vac_entry) => {
@@ -225,8 +253,14 @@ impl Poller {
                 PollCommand::RemoveHandler(msg_id) => {
                     self.subscribers.id.remove(&msg_id);
                 }
-                PollCommand::AddSubscriber(msg_num, tx) => {
-                    match self.subscribers.num.entry(msg_num) {
+                PollCommand::AddSubscriber(msg_id, msg_num, tx) => {
+                    match self
+                        .subscribers
+                        .num
+                        .entry(msg_id)
+                        .or_default()
+                        .entry(msg_num)
+                    {
                         Entry::Vacant(vac_entry) => {
                             vac_entry.insert(tx);
                         }

--- a/crates/core/src/bc_protocol/connection/discovery.rs
+++ b/crates/core/src/bc_protocol/connection/discovery.rs
@@ -175,7 +175,7 @@ impl Discoverer {
                     Ok(rx)
                 } else {
                     Err(Error::SimultaneousSubscription {
-                        msg_num: (tid as u16),
+                        msg_num: Some(tid as u16),
                     })
                 }
             }

--- a/crates/core/src/bc_protocol/errors.rs
+++ b/crates/core/src/bc_protocol/errors.rs
@@ -96,10 +96,10 @@ pub enum Error {
     GenError(#[error(source)] std::sync::Arc<cookie_factory::GenError>),
 
     /// Raised when a connection is subscrbed to more than once for msg_num
-    #[error(display = "Simultaneous subscription, {}", _0)]
+    #[error(display = "Simultaneous subscription, {:?}", _0)]
     SimultaneousSubscription {
         /// The message number that was subscribed to
-        msg_num: u16,
+        msg_num: Option<u16>,
     },
 
     /// Raised when a connection is subscrbed to more than once for msg_id

--- a/crates/core/src/bc_protocol/floodlight_status.rs
+++ b/crates/core/src/bc_protocol/floodlight_status.rs
@@ -45,7 +45,9 @@ impl BcCamera {
         let connection = self.get_connection();
 
         let msg_num = self.new_message_num();
-        let mut sub_set = connection.subscribe(msg_num).await?;
+        let mut sub_set = connection
+            .subscribe(MSG_ID_FLOODLIGHT_MANUAL, msg_num)
+            .await?;
 
         let get = Bc {
             meta: BcMeta {

--- a/crates/core/src/bc_protocol/ledstate.rs
+++ b/crates/core/src/bc_protocol/ledstate.rs
@@ -7,7 +7,7 @@ impl BcCamera {
         self.has_ability_ro("ledState").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_get = connection.subscribe(msg_num).await?;
+        let mut sub_get = connection.subscribe(MSG_ID_GET_LED_STATUS, msg_num).await?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_GET_LED_STATUS,
@@ -56,7 +56,7 @@ impl BcCamera {
         let connection = self.get_connection();
 
         let msg_num = self.new_message_num();
-        let mut sub_set = connection.subscribe(msg_num).await?;
+        let mut sub_set = connection.subscribe(MSG_ID_SET_LED_STATUS, msg_num).await?;
 
         // led_version is a field recieved from the camera but not sent
         // we set to None to ensure we don't send it to the camera

--- a/crates/core/src/bc_protocol/ledstate.rs
+++ b/crates/core/src/bc_protocol/ledstate.rs
@@ -83,18 +83,25 @@ impl BcCamera {
         };
 
         sub_set.send(get).await?;
-        let msg = sub_set.recv().await?;
-
-        if let BcMeta {
-            response_code: 200, ..
-        } = msg.meta
+        if let Ok(reply) =
+            tokio::time::timeout(tokio::time::Duration::from_micros(500), sub_set.recv()).await
         {
-            Ok(())
+            let msg = reply?;
+
+            if let BcMeta {
+                response_code: 200, ..
+            } = msg.meta
+            {
+                Ok(())
+            } else {
+                Err(Error::UnintelligibleReply {
+                    reply: std::sync::Arc::new(Box::new(msg)),
+                    why: "The camera did not except the LEDState xml",
+                })
+            }
         } else {
-            Err(Error::UnintelligibleReply {
-                reply: std::sync::Arc::new(Box::new(msg)),
-                why: "The camera did not except the LEDState xml",
-            })
+            // Some cameras seem to just not send a reply on success, so after 500ms we return Ok
+            Ok(())
         }
     }
 

--- a/crates/core/src/bc_protocol/login.rs
+++ b/crates/core/src/bc_protocol/login.rs
@@ -37,7 +37,7 @@ impl BcCamera {
             let credentials = self.get_credentials();
             let connection = self.get_connection();
             let msg_num = self.new_message_num();
-            let mut sub_login = connection.subscribe(msg_num).await?;
+            let mut sub_login = connection.subscribe(MSG_ID_LOGIN, msg_num).await?;
 
             // Login flow is: Send legacy login message, expect back a modern message with Encryption
             // details.  Then, re-send the login as a modern login message.  Expect back a device info

--- a/crates/core/src/bc_protocol/logout.rs
+++ b/crates/core/src/bc_protocol/logout.rs
@@ -9,7 +9,7 @@ impl BcCamera {
             let credentials = self.get_credentials();
             let connection = self.get_connection();
             let msg_num = self.new_message_num();
-            let sub_logout = connection.subscribe(msg_num).await?;
+            let sub_logout = connection.subscribe(MSG_ID_LOGOUT, msg_num).await?;
 
             let username = credentials.username.clone();
             let password = credentials.password.as_ref().cloned().unwrap_or_default();

--- a/crates/core/src/bc_protocol/motion.rs
+++ b/crates/core/src/bc_protocol/motion.rs
@@ -167,7 +167,7 @@ impl BcCamera {
         let connection = self.get_connection();
 
         let msg_num = self.new_message_num();
-        let mut sub = connection.subscribe(msg_num).await?;
+        let mut sub = connection.subscribe(MSG_ID_MOTION_REQUEST, msg_num).await?;
         let msg = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_MOTION_REQUEST,
@@ -202,7 +202,7 @@ impl BcCamera {
     /// This returns a data structure which can be used to
     /// query motion events
     pub async fn listen_on_motion(&self) -> Result<MotionData> {
-        let msg_num = self.start_motion_query().await?;
+        self.start_motion_query().await?;
 
         let connection = self.get_connection();
 
@@ -213,7 +213,7 @@ impl BcCamera {
         let mut set = JoinSet::new();
         let channel_id = self.channel_id;
         set.spawn(async move {
-            let mut sub = connection.subscribe(msg_num).await?;
+            let mut sub = connection.subscribe_to_id(MSG_ID_MOTION).await?;
 
             loop {
                 tokio::task::yield_now().await;

--- a/crates/core/src/bc_protocol/ping.rs
+++ b/crates/core/src/bc_protocol/ping.rs
@@ -7,7 +7,7 @@ impl BcCamera {
     pub async fn ping(&self) -> Result<()> {
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_ping = connection.subscribe(msg_num).await?;
+        let mut sub_ping = connection.subscribe(MSG_ID_PING, msg_num).await?;
 
         let ping = Bc {
             meta: BcMeta {

--- a/crates/core/src/bc_protocol/pirstate.rs
+++ b/crates/core/src/bc_protocol/pirstate.rs
@@ -12,7 +12,7 @@ impl BcCamera {
         loop {
             retry_interval.tick().await;
             let msg_num = self.new_message_num();
-            let mut sub_get = connection.subscribe(msg_num).await?;
+            let mut sub_get = connection.subscribe(MSG_ID_GET_PIR_ALARM, msg_num).await?;
             let get = Bc {
                 meta: BcMeta {
                     msg_id: MSG_ID_GET_PIR_ALARM,
@@ -70,7 +70,9 @@ impl BcCamera {
         self.has_ability_rw("rfAlarm").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_set = connection.subscribe(msg_num).await?;
+        let mut sub_set = connection
+            .subscribe(MSG_ID_START_PIR_ALARM, msg_num)
+            .await?;
 
         let get = Bc {
             meta: BcMeta {

--- a/crates/core/src/bc_protocol/ptz.rs
+++ b/crates/core/src/bc_protocol/ptz.rs
@@ -25,7 +25,7 @@ impl BcCamera {
         self.has_ability_rw("control").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_set = connection.subscribe(msg_num).await?;
+        let mut sub_set = connection.subscribe(MSG_ID_PTZ_CONTROL, msg_num).await?;
 
         let direction_str = match direction {
             Direction::Up => "up",
@@ -88,7 +88,7 @@ impl BcCamera {
         self.has_ability_rw("control").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_set = connection.subscribe(msg_num).await?;
+        let mut sub_set = connection.subscribe(MSG_ID_GET_PTZ_PRESET, msg_num).await?;
 
         let send = Bc {
             meta: BcMeta {
@@ -136,7 +136,9 @@ impl BcCamera {
         self.has_ability_rw("control").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_set = connection.subscribe(msg_num).await?;
+        let mut sub_set = connection
+            .subscribe(MSG_ID_PTZ_CONTROL_PRESET, msg_num)
+            .await?;
 
         let command = if name.is_some() { "setPos" } else { "toPos" };
         let send = Bc {

--- a/crates/core/src/bc_protocol/ptz.rs
+++ b/crates/core/src/bc_protocol/ptz.rs
@@ -193,7 +193,9 @@ impl BcCamera {
         self.has_ability_rw("control").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_set = connection.subscribe(MSG_ID_PTZ_CONTROL_PRESET, msg_num).await?;
+        let mut sub_set = connection
+            .subscribe(MSG_ID_PTZ_CONTROL_PRESET, msg_num)
+            .await?;
 
         let preset = Preset {
             id: preset_id,

--- a/crates/core/src/bc_protocol/reboot.rs
+++ b/crates/core/src/bc_protocol/reboot.rs
@@ -7,7 +7,7 @@ impl BcCamera {
         self.has_ability_rw("reboot").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub = connection.subscribe(msg_num).await?;
+        let mut sub = connection.subscribe(MSG_ID_REBOOT, msg_num).await?;
 
         let msg = Bc {
             meta: BcMeta {

--- a/crates/core/src/bc_protocol/snap.rs
+++ b/crates/core/src/bc_protocol/snap.rs
@@ -57,7 +57,7 @@ impl BcCamera {
             ..
         }) = msg.body
         {
-            log::debug!("Got snap XML {} with size {}", filename, expected_size);
+            log::trace!("Got snap XML {} with size {}", filename, expected_size);
             // Messages are now sent on ID 109 but not with the same message ID
             // preumably because the camera considers it to be a new message rather
             // than a reply
@@ -68,7 +68,7 @@ impl BcCamera {
             let expected_size = expected_size as usize;
 
             let mut result: Vec<_> = vec![];
-            log::debug!("Waiting for packets on {}", msg_num);
+            log::trace!("Waiting for packets on {}", msg_num);
             let mut msg = sub_get.recv().await?;
 
             while msg.meta.response_code == 200 {
@@ -91,7 +91,7 @@ impl BcCamera {
                         why: "Expected binary data but got something else",
                     });
                 }
-                log::debug!(
+                log::trace!(
                     "Got packet size is now {} of {}",
                     result.len(),
                     expected_size
@@ -114,7 +114,7 @@ impl BcCamera {
                         // Add last data if present (may be zero if preveious packet contained it)
                         result.extend_from_slice(&data);
                     }
-                    log::debug!(
+                    log::trace!(
                         "Got all packets size is now {} of {}",
                         result.len(),
                         expected_size
@@ -140,7 +140,7 @@ impl BcCamera {
             //     .take(expected_size)
             //     .try_collect()
             //     .await?;
-            log::debug!("Snapshot recieved: {} of {}", result.len(), expected_size);
+            log::trace!("Snapshot recieved: {} of {}", result.len(), expected_size);
             Ok(result)
         } else {
             Err(Error::UnintelligibleReply {

--- a/crates/core/src/bc_protocol/snap.rs
+++ b/crates/core/src/bc_protocol/snap.rs
@@ -1,0 +1,79 @@
+use futures::{StreamExt, TryStreamExt};
+
+use super::{BcCamera, Error, Result};
+use crate::bc::{model::*, xml::*};
+
+impl BcCamera {
+    /// Get the snapshot image
+    pub async fn get_snapshot(&self) -> Result<Vec<u8>> {
+        let connection = self.get_connection();
+        let msg_num = self.new_message_num();
+        let mut sub_get = connection.subscribe(msg_num).await?;
+        let get = Bc {
+            meta: BcMeta {
+                msg_id: MSG_ID_SNAP,
+                channel_id: self.channel_id,
+                msg_num,
+                response_code: 0,
+                stream_type: 0,
+                class: 0x6414,
+            },
+            body: BcBody::ModernMsg(ModernMsg {
+                extension: Some(Extension {
+                    channel_id: Some(self.channel_id),
+                    ..Default::default()
+                }),
+                payload: Some(BcPayloads::BcXml(BcXml {
+                    snap: Some(Snap {
+                        channel_id: self.channel_id,
+                        logic_channel: Some(self.channel_id),
+                        time: 0,
+                        full_frame: Some(0),
+                        stream_type: Some("main".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })),
+            }),
+        };
+
+        sub_get.send(get).await?;
+        let msg = sub_get.recv().await?;
+        if msg.meta.response_code != 200 {
+            return Err(Error::CameraServiceUnavaliable);
+        }
+
+        if let BcBody::ModernMsg(ModernMsg {
+            payload:
+                Some(BcPayloads::BcXml(BcXml {
+                    snap:
+                        Some(Snap {
+                            file_name: Some(filename),
+                            picture_size: Some(expected_size),
+                            ..
+                        }),
+                    ..
+                })),
+            ..
+        }) = msg.body
+        {
+            log::trace!("Got snap {} with size {}", filename, expected_size);
+            let expected_size = expected_size as usize;
+
+            let binary_stream = sub_get.payload_stream();
+            let result: Vec<_> = binary_stream
+                .map_ok(|i| tokio_stream::iter(i).map(Result::Ok))
+                .try_flatten()
+                .take(expected_size)
+                .try_collect()
+                .await?;
+            log::trace!("Got whole of the snap: {}", result.len());
+            Ok(result)
+        } else {
+            Err(Error::UnintelligibleReply {
+                reply: std::sync::Arc::new(Box::new(msg)),
+                why: "Expected Snap xml but it was not recieved",
+            })
+        }
+    }
+}

--- a/crates/core/src/bc_protocol/talk.rs
+++ b/crates/core/src/bc_protocol/talk.rs
@@ -17,7 +17,7 @@ impl BcCamera {
         let connection = self.get_connection();
 
         let msg_num = self.new_message_num();
-        let mut sub = connection.subscribe(msg_num).await?;
+        let mut sub = connection.subscribe(MSG_ID_TALKRESET, msg_num).await?;
 
         let msg = Bc {
             meta: BcMeta {
@@ -60,7 +60,7 @@ impl BcCamera {
     pub async fn talk_ability(&self) -> Result<TalkAbility> {
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_get = connection.subscribe(msg_num).await?;
+        let mut sub_get = connection.subscribe(MSG_ID_TALKABILITY, msg_num).await?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_TALKABILITY,
@@ -120,7 +120,7 @@ impl BcCamera {
         let connection = self.get_connection();
 
         let msg_num = self.new_message_num();
-        let mut sub = connection.subscribe(msg_num).await?;
+        let mut sub = connection.subscribe(MSG_ID_TALKCONFIG, msg_num).await?;
 
         if &talk_config.audio_config.audio_type != "adpcm" {
             return Err(Error::UnknownTalkEncoding);
@@ -182,7 +182,7 @@ impl BcCamera {
 
         let full_block_size = block_size + 4; // Block size + predictor state
         let msg_num = self.new_message_num();
-        let sub = connection.subscribe(msg_num).await?;
+        let sub = connection.subscribe(MSG_ID_TALK, msg_num).await?;
 
         const BLOCK_PER_PAYLOAD: usize = 4;
         const BLOCK_HEADER_SIZE: usize = 4;
@@ -261,7 +261,7 @@ impl BcCamera {
         let connection = self.get_connection();
 
         let msg_num = self.new_message_num();
-        let mut sub = connection.subscribe(msg_num).await?;
+        let mut sub = connection.subscribe(MSG_ID_TALKCONFIG, msg_num).await?;
 
         if &talk_config.audio_config.audio_type != "adpcm" {
             return Err(Error::UnknownTalkEncoding);
@@ -323,7 +323,7 @@ impl BcCamera {
 
         let full_block_size = block_size + 4; // Block size + predictor state
         let msg_num = self.new_message_num();
-        let sub = connection.subscribe(msg_num).await?;
+        let sub = connection.subscribe(MSG_ID_TALK, msg_num).await?;
 
         const BLOCK_PER_PAYLOAD: usize = 1;
         const BLOCK_HEADER_SIZE: usize = 4;

--- a/crates/core/src/bc_protocol/time.rs
+++ b/crates/core/src/bc_protocol/time.rs
@@ -17,7 +17,7 @@ impl BcCamera {
         self.has_ability_ro("general").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_get_general = connection.subscribe(msg_num).await?;
+        let mut sub_get_general = connection.subscribe(MSG_ID_GET_GENERAL, msg_num).await?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_GET_GENERAL,
@@ -102,7 +102,7 @@ impl BcCamera {
         self.has_ability_rw("general").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_set_general = connection.subscribe(msg_num).await?;
+        let mut sub_set_general = connection.subscribe(MSG_ID_SET_GENERAL, msg_num).await?;
         let set = Bc::new_from_xml(
             BcMeta {
                 msg_id: MSG_ID_SET_GENERAL,

--- a/crates/core/src/bc_protocol/version.rs
+++ b/crates/core/src/bc_protocol/version.rs
@@ -7,7 +7,7 @@ impl BcCamera {
         self.has_ability_ro("version").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
-        let mut sub_version = connection.subscribe(msg_num).await?;
+        let mut sub_version = connection.subscribe(MSG_ID_VERSION, msg_num).await?;
 
         let version = Bc {
             meta: BcMeta {

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -38,6 +38,10 @@ address = "192.168.1.187:9000"
 # mqtt.broker_addr = "192.168.1.122"
 # mqtt.port = 1883
 # mqtt.credentials = ["mqtt_user", "mqtt_password"]
+# MQTT Discovery: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+# mqtt.discovery.topic = homeassistant # Uncomment to enable
+# If using discovery, _ characters are replaced with spaces in the name and title case is applied
+# mqtt.discovery.features = ["floodlight"] # Uncomment if this camera has a spotlight/floodlight
 
 # If you use a battery camera: **Instead** of an `address` supply the uid
 # as follows

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -39,7 +39,7 @@ address = "192.168.1.187:9000"
 # mqtt.port = 1883
 # mqtt.credentials = ["mqtt_user", "mqtt_password"]
 # MQTT Discovery: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
-# mqtt.discovery.topic = homeassistant # Uncomment to enable
+# mqtt.discovery.topic = "homeassistant" # Uncomment to enable
 # If using discovery, _ characters are replaced with spaces in the name and title case is applied
 # mqtt.discovery.features = ["floodlight"] # Uncomment if this camera has a spotlight/floodlight
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,16 @@ pub(crate) struct MqttConfig {
 
     #[serde(default)]
     pub(crate) client_auth: Option<(std::path::PathBuf, std::path::PathBuf)>,
+
+    #[serde(default)]
+    pub(crate) discovery: Option<MqttDiscoveryConfig>,
+}
+
+#[derive(Debug, Deserialize, Clone, Validate)]
+pub(crate) struct MqttDiscoveryConfig {
+    pub(crate) topic: String,
+
+    pub(crate) features: Vec<String>,
 }
 
 fn validate_mqtt_config(config: &MqttConfig) -> Result<(), ValidationError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,10 @@
+use crate::mqtt::Discoveries;
 use lazy_static::lazy_static;
 use neolink_core::bc_protocol::{DiscoveryMethods, PrintFormat};
 use regex::Regex;
 use serde::Deserialize;
 use std::clone::Clone;
+use std::collections::HashSet;
 use validator::{Validate, ValidationError};
 use validator_derive::Validate;
 
@@ -155,7 +157,7 @@ pub(crate) struct MqttConfig {
 pub(crate) struct MqttDiscoveryConfig {
     pub(crate) topic: String,
 
-    pub(crate) features: Vec<String>,
+    pub(crate) features: HashSet<Discoveries>,
 }
 
 fn validate_mqtt_config(config: &MqttConfig) -> Result<(), ValidationError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,6 +148,17 @@ pub(crate) struct MqttConfig {
 
     #[serde(default)]
     pub(crate) client_auth: Option<(std::path::PathBuf, std::path::PathBuf)>,
+    
+    #[serde(default = "default_true")]
+    pub(crate) enable_motion: bool,
+    #[serde(default = "default_true")]
+    pub(crate) enable_pings: bool,
+    #[serde(default = "default_true")]
+    pub(crate) enable_light: bool,
+    #[serde(default = "default_true")]
+    pub(crate) enable_battery: bool,
+    #[serde(default = "default_true")]
+    pub(crate) enable_preview: bool,
 
     #[serde(default)]
     pub(crate) discovery: Option<MqttDiscoveryConfig>,
@@ -168,6 +179,10 @@ fn validate_mqtt_config(config: &MqttConfig) -> Result<(), ValidationError> {
     } else {
         Ok(())
     }
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 fn default_mqtt() -> Option<MqttConfig> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,7 +148,7 @@ pub(crate) struct MqttConfig {
 
     #[serde(default)]
     pub(crate) client_auth: Option<(std::path::PathBuf, std::path::PathBuf)>,
-    
+
     #[serde(default = "default_true")]
     pub(crate) enable_motion: bool,
     #[serde(default = "default_true")]

--- a/src/mqtt/discovery.rs
+++ b/src/mqtt/discovery.rs
@@ -1,0 +1,235 @@
+//! Enable and configures home assistant MQTTT discovery
+//!
+//! https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+//!
+use anyhow::{Context, Result};
+use heck::ToTitleCase;
+use log::*;
+use std::sync::Arc;
+
+use super::mqttc::MqttSender;
+use crate::config::{CameraConfig, MqttDiscoveryConfig};
+use serde::{Serialize, Serializer};
+
+#[derive(Debug, Clone)]
+struct DiscoveryConnection {
+    connection_type: String,
+    connection_id: String,
+}
+
+impl Serialize for DiscoveryConnection {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        vec![&self.connection_type, &self.connection_id].serialize(serializer)
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+struct DiscoveryDevice {
+    name: String,
+    connections: Vec<DiscoveryConnection>,
+    identifiers: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manufacturer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sw_version: Option<String>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+struct DiscoveryAvaliablity {
+    topic: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload_available: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload_not_available: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+struct DiscoveryLight {
+    name: String,
+    unique_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state_topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state_value_template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command_topic: Option<String>,
+    payload_on: String,
+    payload_off: String,
+    device: DiscoveryDevice,
+    availability: DiscoveryAvaliablity,
+}
+
+#[derive(Serialize, Debug)]
+#[allow(dead_code)]
+enum Encoding {
+    None,
+    #[serde(rename = "b64")]
+    Base64,
+}
+
+impl Encoding {
+    fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+#[derive(Serialize, Debug)]
+struct DiscoveryCamera {
+    name: String,
+    unique_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    topic: String,
+    device: DiscoveryDevice,
+    availability: DiscoveryAvaliablity,
+    #[serde(skip_serializing_if = "Encoding::is_none")]
+    image_encoding: Encoding,
+}
+
+/// Enables MQTT discovery for a camera. See docs at https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+pub(crate) async fn enable_discovery(
+    discovery_config: &MqttDiscoveryConfig,
+    mqtt_sender: &MqttSender,
+    cam_config: &Arc<CameraConfig>,
+) -> Result<()> {
+    debug!("Enabling MQTT discovery for {}", cam_config.name);
+
+    let mut connections = vec![];
+    if let Some(addr) = &cam_config.camera_addr {
+        connections.push(DiscoveryConnection {
+            connection_type: "camera_addr".to_string(),
+            connection_id: addr.clone(),
+        });
+    }
+    if let Some(uid) = &cam_config.camera_uid {
+        connections.push(DiscoveryConnection {
+            connection_type: "camera_uid".to_string(),
+            connection_id: uid.clone(),
+        });
+    }
+
+    if connections.is_empty() {
+        error!(
+            "No connections found for camera {}, either addr or UID must be supplied",
+            cam_config.name
+        );
+        return Ok(());
+    }
+
+    let friendly_name = cam_config.name.replace('_', " ").to_title_case();
+    let device = DiscoveryDevice {
+        name: friendly_name.clone(),
+        connections,
+        identifiers: vec![format!("neolink_{}", cam_config.name)],
+        manufacturer: Some("Reolink".to_string()),
+        model: Some("Neolink".to_string()),
+        sw_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+    };
+
+    let availability = DiscoveryAvaliablity {
+        topic: format!("neolink/{}/status", cam_config.name),
+        payload_available: Some("connected".to_string()),
+        payload_not_available: None,
+    };
+
+    for feature in &discovery_config.features {
+        match feature.as_str() {
+            "floodlight" => {
+                let config_data = DiscoveryLight {
+                    // Common across all potential features
+                    device: device.clone(),
+                    availability: availability.clone(),
+
+                    // Identifiers
+                    name: format!("{} Floodlight", friendly_name.as_str()),
+                    unique_id: format!("neolink_{}_floodlight", cam_config.name),
+                    // Match native home assistant integration: https://github.com/home-assistant/core/blob/dev/homeassistant/components/reolink/light.py#L49
+                    icon: Some("mdi:spotlight-beam".to_string()),
+
+                    // State
+                    state_topic: Some(format!("neolink/{}/status/floodlight", cam_config.name)),
+                    state_value_template: Some("{{ value_json.state }}".to_string()),
+
+                    // Control
+                    command_topic: Some(format!("neolink/{}/control/floodlight", cam_config.name)),
+                    // Lowercase payloads to match neolink convention
+                    payload_on: "on".to_string(),
+                    payload_off: "off".to_string(),
+                };
+
+                // Each feature needs to be individually registered
+                mqtt_sender
+                    .send_message_with_root_topic(
+                        &format!("{}/light", discovery_config.topic),
+                        "config",
+                        &serde_json::to_string(&config_data).with_context(|| {
+                            "Cound not serialise discovery light config into json"
+                        })?,
+                        true,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to publish floodlight auto-discover data on over MQTT for {}",
+                            cam_config.name
+                        )
+                    })?;
+            }
+            "camera" => {
+                let config_data = DiscoveryCamera {
+                    // Common across all potential features
+                    device: device.clone(),
+                    availability: availability.clone(),
+
+                    // Identifiers
+                    name: format!("{} Camera", friendly_name.as_str()),
+                    unique_id: format!("neolink_{}_camera", cam_config.name),
+                    icon: Some("mdi:camera-iris".to_string()),
+                    
+                    // Camera specific
+                    topic: format!("neolink/{}/status/preview", cam_config.name),
+                    image_encoding: Encoding::Base64,
+                };
+
+                // Each feature needs to be individually registered
+                mqtt_sender
+                    .send_message_with_root_topic(
+                        &format!("{}/camera", discovery_config.topic),
+                        "config",
+                        &serde_json::to_string(&config_data).with_context(|| {
+                            "Cound not serialise discovery camera config into json"
+                        })?,
+                        true,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to publish camera auto-discover data on over MQTT for {}",
+                            cam_config.name
+                        )
+                    })?;
+            }
+            _ => {
+                error!(
+                    "Unsupported MQTT feature {} for {}",
+                    feature, cam_config.name
+                );
+            }
+        }
+    }
+
+    info!(
+        "Enabled MQTT discovery for {} with friendly name {}",
+        cam_config.name,
+        friendly_name.as_str()
+    );
+
+    Ok(())
+}

--- a/src/mqtt/discovery.rs
+++ b/src/mqtt/discovery.rs
@@ -9,7 +9,25 @@ use std::sync::Arc;
 
 use super::mqttc::MqttSender;
 use crate::config::{CameraConfig, MqttDiscoveryConfig};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Copy, Hash)]
+pub(crate) enum Discoveries {
+    #[serde(alias = "floodlight", alias = "light")]
+    Floodlight,
+    #[serde(alias = "camera")]
+    Camera,
+    #[serde(alias = "motion", alias = "md", alias = "pir")]
+    Motion,
+    #[serde(alias = "led")]
+    Led,
+    #[serde(alias = "ir")]
+    Ir,
+    #[serde(alias = "reboot")]
+    Reboot,
+    #[serde(alias = "pt")]
+    Pt,
+}
 
 #[derive(Debug, Clone)]
 struct DiscoveryConnection {
@@ -210,8 +228,8 @@ pub(crate) async fn enable_discovery(
     };
 
     for feature in &discovery_config.features {
-        match feature.as_str() {
-            "floodlight" => {
+        match feature {
+            Discoveries::Floodlight => {
                 let config_data = DiscoveryLight {
                     // Common across all potential features
                     device: device.clone(),
@@ -255,7 +273,7 @@ pub(crate) async fn enable_discovery(
                         )
                     })?;
             }
-            "camera" => {
+            Discoveries::Camera => {
                 let config_data = DiscoveryCamera {
                     // Common across all potential features
                     device: device.clone(),
@@ -292,7 +310,7 @@ pub(crate) async fn enable_discovery(
                         )
                     })?;
             }
-            "led" => {
+            Discoveries::Led => {
                 let config_data = DiscoverySwitch {
                     // Common across all potential features
                     device: device.clone(),
@@ -333,7 +351,7 @@ pub(crate) async fn enable_discovery(
                         )
                     })?;
             }
-            "ir" => {
+            Discoveries::Ir => {
                 let config_data = DiscoverySelect {
                     // Common across all potential features
                     device: device.clone(),
@@ -371,7 +389,7 @@ pub(crate) async fn enable_discovery(
                         )
                     })?;
             }
-            "motion" => {
+            Discoveries::Motion => {
                 let config_data = DiscoveryBinarySensor {
                     // Common across all potential features
                     device: device.clone(),
@@ -409,7 +427,7 @@ pub(crate) async fn enable_discovery(
                         )
                     })?;
             }
-            "reboot" => {
+            Discoveries::Reboot => {
                 let config_data = DiscoveryButton {
                     // Common across all potential features
                     device: device.clone(),
@@ -446,7 +464,7 @@ pub(crate) async fn enable_discovery(
                         )
                     })?;
             }
-            "pt" => {
+            Discoveries::Pt => {
                 for dir in ["left", "right", "up", "down"] {
                     let config_data = DiscoveryButton {
                         // Common across all potential features
@@ -484,12 +502,6 @@ pub(crate) async fn enable_discovery(
                             )
                         })?;
                 }
-            }
-            _ => {
-                error!(
-                    "Unsupported MQTT feature {} for {}",
-                    feature, cam_config.name
-                );
             }
         }
     }

--- a/src/mqtt/discovery.rs
+++ b/src/mqtt/discovery.rs
@@ -192,7 +192,7 @@ pub(crate) async fn enable_discovery(
                     name: format!("{} Camera", friendly_name.as_str()),
                     unique_id: format!("neolink_{}_camera", cam_config.name),
                     icon: Some("mdi:camera-iris".to_string()),
-                    
+
                     // Camera specific
                     topic: format!("neolink/{}/status/preview", cam_config.name),
                     image_encoding: Encoding::Base64,

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -381,10 +381,14 @@ impl SnapThread {
                     tries = 1;
                     info
                 }
-                Err(neolink_core::Error::UnintelligibleReply { .. }) => {
+                Err(neolink_core::Error::UnintelligibleReply { reply, why }) => {
+                    log::debug!("Reply: {:?}, why: {:?}", reply, why);
                     // Try again later
                     tries += 1;
                     continue;
+                }
+                Err(neolink_core::Error::CameraServiceUnavaliable) => {
+                    futures::future::pending().await
                 }
                 Err(e) => return Err(e.into()),
             };
@@ -413,6 +417,9 @@ impl BatteryLevelThread {
                     // Try again later
                     tries += 1;
                     continue;
+                }
+                Err(neolink_core::Error::CameraServiceUnavaliable) => {
+                    futures::future::pending().await
                 }
                 Err(e) => return Err(e.into()),
             };

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -237,7 +237,7 @@ impl EventCamThread {
             val = async {
                 info!("{}: Listening to Camera Motion", camera_config.name);
                 motion_thread.run().await
-            } => {
+            }, if camera_config.mqtt.as_ref().expect("Should have an mqtt config at this point").enable_motion => {
                 if let Err(e) = val {
                     error!("Motion thread aborted: {:?}", e);
                     Err(e)
@@ -249,7 +249,7 @@ impl EventCamThread {
             val = async {
                 debug!("{}: Starting Pings", camera_config.name);
                 keepalive_thread.run().await
-            } => {
+            }, if camera_config.mqtt.as_ref().expect("Should have an mqtt config at this point").enable_pings => {
                 if let Err(e) = val {
                     debug!("Ping thread aborted: {:?}", e);
                     Err(e)
@@ -261,7 +261,7 @@ impl EventCamThread {
             val = async {
                 info!("{}: Listening to FloodLight Status", camera_config.name);
                 flight_thread.run().await
-            } => {
+            }, if camera_config.mqtt.as_ref().expect("Should have an mqtt config at this point").enable_light => {
                 if let Err(e) = val {
                     error!("FloodLight thread aborted: {:?}", e);
                     Err(e)
@@ -273,7 +273,7 @@ impl EventCamThread {
             val = async {
                 info!("{}: Updating Preview", camera_config.name);
                 snap_thread.run().await
-            } => {
+            }, if camera_config.mqtt.as_ref().expect("Should have an mqtt config at this point").enable_preview => {
                 if let Err(e) = val {
                     error!("Snap thread aborted: {:?}", e);
                     Err(e)
@@ -285,7 +285,7 @@ impl EventCamThread {
             val = async {
                 info!("{}: Updating Battery Level", camera_config.name);
                 battery_thread.run().await
-            } => {
+            }, if camera_config.mqtt.as_ref().expect("Should have an mqtt config at this point").enable_battery => {
                 if let Err(e) = val {
                     error!("Battery thread aborted: {:?}", e);
                     Err(e)

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -388,6 +388,7 @@ impl SnapThread {
                     continue;
                 }
                 Err(neolink_core::Error::CameraServiceUnavaliable) => {
+                    log::debug!("Snap not supported");
                     futures::future::pending().await
                 }
                 Err(e) => return Err(e.into()),
@@ -405,7 +406,7 @@ struct BatteryLevelThread {
 impl BatteryLevelThread {
     async fn run(&mut self) -> Result<()> {
         let mut tries = 0;
-        let base_duration = Duration::from_millis(500);
+        let base_duration = Duration::from_secs(15);
         loop {
             tokio::time::sleep(base_duration.saturating_mul(tries)).await;
             let battery = match self.camera.battery_info().await {
@@ -419,6 +420,7 @@ impl BatteryLevelThread {
                     continue;
                 }
                 Err(neolink_core::Error::CameraServiceUnavaliable) => {
+                    log::debug!("Battery not supported");
                     futures::future::pending().await
                 }
                 Err(e) => return Err(e.into()),

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -255,19 +255,19 @@ async fn enable_discovery(
     }
 
     let friendly_name = cam_config.name.replace("_", " ").to_title_case();
-    let device = Arc::new(object! {
+    let device = object! {
         connections: connections,
         name: friendly_name.as_str(),
         identifiers: array![format!("neolink_{}", cam_config.name)],
         manufacturer: "Reolink",
         model: "Neolink",
         sw_version: env!("CARGO_PKG_VERSION"),
-    });
+    };
 
-    let availability = Arc::new(object! {
+    let availability = object! {
         topic: format!("neolink/{}/status", cam_config.name),
         payload_available: "connected",
-    });
+    };
 
     for feature in &discovery_config.features {
         match feature.as_str() {
@@ -276,8 +276,8 @@ async fn enable_discovery(
 
                 let config_data = object! {
                     // Common across all potential features
-                    device: Arc::try_unwrap(device.clone()).unwrap(),
-                    availability: Arc::try_unwrap(availability.clone()).unwrap(),
+                    device: device.clone(),
+                    availability: availability.clone(),
 
                     // Identifiers
                     name: format!("{} Floodlight", friendly_name.as_str()),

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -223,6 +223,14 @@ async fn listen_on_camera(cam_config: Arc<CameraConfig>, mqtt_config: &MqttConfi
                             format!("Failed to publish preview over MQTT for {}", camera_name)
                         })?;
                 }
+                Messages::BatteryLevel(data) => {
+                    mqtt_sender_cam
+                        .send_message("status/battery_level", format!("{}", data).as_str(), true)
+                        .await
+                        .with_context(|| {
+                            format!("Failed to publish battery level over MQTT for {}", camera_name)
+                        })?;
+                }
                 _ => {}
             }
         }

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -66,9 +66,9 @@ mod mqttc;
 use crate::config::{CameraConfig, Config, MqttConfig};
 use anyhow::{anyhow, Context, Error, Result};
 pub(crate) use cmdline::Opt;
+pub(crate) use discovery::Discoveries;
 use event_cam::EventCam;
 pub(crate) use event_cam::{Direction, Messages};
-pub(crate) use discovery::Discoveries;
 use log::*;
 use mqttc::{Mqtt, MqttReplyRef};
 

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -68,6 +68,7 @@ use anyhow::{anyhow, Context, Error, Result};
 pub(crate) use cmdline::Opt;
 use event_cam::EventCam;
 pub(crate) use event_cam::{Direction, Messages};
+pub(crate) use discovery::Discoveries;
 use log::*;
 use mqttc::{Mqtt, MqttReplyRef};
 

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -228,7 +228,10 @@ async fn listen_on_camera(cam_config: Arc<CameraConfig>, mqtt_config: &MqttConfi
                         .send_message("status/battery_level", format!("{}", data).as_str(), true)
                         .await
                         .with_context(|| {
-                            format!("Failed to publish battery level over MQTT for {}", camera_name)
+                            format!(
+                                "Failed to publish battery level over MQTT for {}",
+                                camera_name
+                            )
                         })?;
                 }
                 _ => {}

--- a/src/mqtt/mqttc.rs
+++ b/src/mqtt/mqttc.rs
@@ -50,19 +50,31 @@ pub(crate) struct MqttSender {
 }
 
 impl MqttSender {
-    pub async fn send_message(
+    pub async fn send_message_with_root_topic(
         &self,
+        root_topic: &str,
         sub_topic: &str,
         message: &str,
         retain: bool,
     ) -> Result<(), ClientError> {
         self.client
             .publish(
-                format!("neolink/{}/{}", self.name, sub_topic),
+                format!("{}/{}/{}", root_topic, self.name, sub_topic),
                 QoS::AtLeastOnce,
                 retain,
                 message,
             )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn send_message(
+        &self,
+        sub_topic: &str,
+        message: &str,
+        retain: bool,
+    ) -> Result<(), ClientError> {
+        self.send_message_with_root_topic("neolink", sub_topic, message, retain)
             .await?;
         Ok(())
     }

--- a/src/mqtt/mqttc.rs
+++ b/src/mqtt/mqttc.rs
@@ -168,6 +168,8 @@ impl Mqtt {
             &config.broker_addr,
             config.port,
         );
+        let max_size = 100 * (1024 * 1024);
+        mqttoptions.set_max_packet_size(max_size, max_size);
 
         // Use TLS if ca path is set
         if let Some(ca_path) = &config.ca {


### PR DESCRIPTION
Adds config options to enable MQTT Discovery as documented here: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery

As discussed in https://github.com/QuantumEntangledAndy/neolink/pull/14#issuecomment-1561076262

Unfortinuately, the floodlight/spotlight doesn't show up in the `<AbilityInfo>` returned by the camera: https://github.com/QuantumEntangledAndy/neolink/pull/14#issuecomment-1563728970

Open to other suggestions on how to detect or enable these options.