### PR TITLE
Refractor/buffer

### DIFF
--- a/crates/core/src/bc_protocol/ptz.rs
+++ b/crates/core/src/bc_protocol/ptz.rs
@@ -139,12 +139,6 @@ impl BcCamera {
         let mut sub_set = connection.subscribe(msg_num).await?;
 
         let command = if name.is_some() { "setPos" } else { "toPos" };
-        let preset = Preset {
-            id: preset_id,
-            name,
-            command: Some(command.to_string()),
-            ..Default::default()
-        };
         let send = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_PTZ_CONTROL_PRESET,
@@ -163,7 +157,11 @@ impl BcCamera {
                 payload: Some(BcPayloads::BcXml(BcXml {
                     ptz_preset: Some(PtzPreset {
                         preset_list: Some(PresetList {
-                            preset: vec![preset],
+                            preset: vec![Preset {
+                                id: preset_id,
+                                name,
+                                command: Some(command.to_string()),
+                            }],
                         }),
                         ..Default::default()
                     }),

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,7 +104,7 @@ pub(crate) struct CameraConfig {
     pub(crate) update_time: bool,
 
     #[validate(range(
-        min = 10,
+        min = 0,
         max = 500,
         message = "Invalid buffer size",
         code = "buffer_size"

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,7 +260,7 @@ fn default_smoothing() -> bool {
 }
 
 fn default_buffer_size() -> usize {
-    100
+    25
 }
 
 pub(crate) static RESERVED_NAMES: &[&str] = &["anyone", "anonymous"];

--- a/src/rtsp/gst/sender.rs
+++ b/src/rtsp/gst/sender.rs
@@ -783,6 +783,7 @@ impl NeoMediaSender {
                                                 runtime.try_into().unwrap(),
                                             );
                                             gst_buf_mut.set_dts(time);
+                                            gst_buf_mut.set_pts(time);
                                             let mut gst_buf_data =
                                                 gst_buf_mut.map_writable().unwrap();
                                             gst_buf_data.copy_from_slice(buf.as_slice());
@@ -841,6 +842,7 @@ impl NeoMediaSender {
                                                 runtime.try_into().unwrap(),
                                             );
                                             gst_buf_mut.set_dts(time);
+                                            gst_buf_mut.set_pts(time);
                                             let mut gst_buf_data =
                                                 gst_buf_mut.map_writable().unwrap();
                                             gst_buf_data.copy_from_slice(buf.as_slice());

--- a/src/rtsp/gst/sender.rs
+++ b/src/rtsp/gst/sender.rs
@@ -116,7 +116,7 @@ impl NeoBuffer {
     }
 
     pub(crate) fn ready(&self) -> bool {
-        self.buf.len() >= self.live_size()
+        self.buf.len() >= self.live_size() + HISTORICAL_BUFFER_SIZE / 2
     }
 
     fn end_time(&self) -> Option<FrameTime> {
@@ -623,12 +623,12 @@ impl NeoMediaSender {
 
                 // Send preprocess now
                 self.send_buffers(preprocess.as_slice(), true).await?;
-                trace!("Preprocessed");
+                trace!("Preprocessed: {}", preprocess.len());
                 // Send these later
                 for frame in buffer.drain(..) {
                     self.buffer.buf.push_back(frame);
                 }
-                trace!("Buffer filled");
+                trace!("Buffer filled: {}", self.buffer.buf.len());
 
                 self.jump_to_live().await?;
             } else {

--- a/src/rtsp/gst/sender.rs
+++ b/src/rtsp/gst/sender.rs
@@ -415,7 +415,7 @@ impl NeoMediaSender {
             command_sender: tx,
             inited: false,
             playing: true,
-            use_smoothing,
+            use_smoothing: use_smoothing && buffer_size > 0,
         }
     }
 

--- a/src/rtsp/gst/sender.rs
+++ b/src/rtsp/gst/sender.rs
@@ -489,6 +489,10 @@ impl NeoMediaSender {
 
     fn target_live_for(buffer: &NeoBuffer) -> Option<FrameTime> {
         let target_idx = buffer.live_size();
+        if target_idx == 0 {
+            // No buffer needed grab the last
+            return buffer.buf.back().map(|item| item.time);
+        }
         let stamps = buffer.buf.iter().map(|item| item.time).collect::<Vec<_>>();
 
         if stamps.len() >= target_idx {


### PR DESCRIPTION
Some changes to the way buffer works. Most importantly removed the refilling of the buffer by a pause.

Also added it so that you can just play frames as they are recieved by setting `buffer_size` to `0` in the config. This will just drop the cameras time stamps and stamp them as they are sent