### PR TITLE
Seperate set and assign presets. Also add queury messages to mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,10 @@ Control messages:
 - `/control/ir [on|off|auto]` Turn IR lights on/off or automatically via light
   detection
 - `/control/reboot` Reboot the camera
-- `/control/ptz [up|down|left|right|in|out]` (amount) Control the PTZ
+- `/control/ptz [up|down|left|right|in|out] (amount)` Control the PTZ
   movements, amount defaults to 32.0
-- `/control/preset [id]` Move to PTZ preset `id`
+- `/control/ptz/preset [id]` Move the camera to a PTZ preset
+- `/control/ptz/assign [id] [name]` Set the current PTZ position to a preset ID and name
 - `/control/pir [on|off]`
 
 Status Messages:
@@ -202,11 +203,14 @@ Status Messages:
   of the battery status
 - `/status/pir` Sent in reply to a `/query/pir` an XML encoded version of the
   pir status
+- `/status/ptz/preset` Sent in reply to a `/query/ptz/preset` an XML encoded version of the
+  PTZ presets
 
 Query Messages:
 
 - `/query/battery` Request that the camera reports its battery level
 - `/query/pir` Request that the camera reports its pir status
+- `/query/ptz/preset` Request that the camera reports its PTZ presets
 
 ### Pause
 

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -583,7 +583,7 @@ pub struct PtzPreset {
     pub channel_id: u8,
     /// List of presets
     #[yaserde(rename = "presetList")]
-    pub preset_list: Option<PresetList>,
+    pub preset_list: PresetList,
 }
 
 /// A preset list
@@ -597,11 +597,11 @@ pub struct PresetList {
 #[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
 pub struct Preset {
     /// The ID of the preset
-    pub id: i8,
+    pub id: u8,
     /// The preset name
     pub name: Option<String>,
     /// Command: Known values: `"toPos"` and `"setPos"`
-    pub command: Option<String>,
+    pub command: String,
 }
 
 /// A list of battery infos. This message is sent from the camera as

--- a/crates/core/src/bc_protocol/ptz.rs
+++ b/crates/core/src/bc_protocol/ptz.rs
@@ -129,21 +129,19 @@ impl BcCamera {
         }
     }
 
-    /// Set a PTZ preset. If a [name] is given the current position will be saved as a preset
-    /// with the given [preset_id] and [name], otherwise the camera will attempt to move to the
-    /// preset with the given ID.
-    pub async fn set_ptz_preset(&self, preset_id: i8, name: Option<String>) -> Result<()> {
+    /// Set a PTZ preset.
+    ///
+    /// The current position will be saved as a preset with the given [preset_id] and [name]
+    pub async fn set_ptz_preset(&self, preset_id: u8, name: String) -> Result<()> {
         self.has_ability_rw("control").await?;
         let connection = self.get_connection();
         let msg_num = self.new_message_num();
         let mut sub_set = connection.subscribe(msg_num).await?;
 
-        let command = if name.is_some() { "setPos" } else { "toPos" };
         let preset = Preset {
             id: preset_id,
-            name,
-            command: Some(command.to_string()),
-            ..Default::default()
+            name: Some(name),
+            command: "setPos".to_owned(),
         };
         let send = Bc {
             meta: BcMeta {
@@ -162,9 +160,64 @@ impl BcCamera {
                 }),
                 payload: Some(BcPayloads::BcXml(BcXml {
                     ptz_preset: Some(PtzPreset {
-                        preset_list: Some(PresetList {
+                        preset_list: PresetList {
                             preset: vec![preset],
-                        }),
+                        },
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })),
+            }),
+        };
+
+        sub_set.send(send).await?;
+        let msg = sub_set.recv().await?;
+
+        if let BcMeta {
+            response_code: 200, ..
+        } = msg.meta
+        {
+            Ok(())
+        } else {
+            Err(Error::UnintelligibleReply {
+                reply: std::sync::Arc::new(Box::new(msg)),
+                why: "The camera did not accept the PtzPreset xml",
+            })
+        }
+    }
+
+    /// The camera will attempt to move to the preset with the given ID.
+    pub async fn moveto_ptz_preset(&self, preset_id: u8) -> Result<()> {
+        self.has_ability_rw("control").await?;
+        let connection = self.get_connection();
+        let msg_num = self.new_message_num();
+        let mut sub_set = connection.subscribe(msg_num).await?;
+
+        let preset = Preset {
+            id: preset_id,
+            name: None,
+            command: "toPos".to_owned(),
+        };
+        let send = Bc {
+            meta: BcMeta {
+                msg_id: MSG_ID_PTZ_CONTROL_PRESET,
+                channel_id: self.channel_id,
+                msg_num,
+                response_code: 0,
+                stream_type: 0,
+                class: 0x6414,
+            },
+
+            body: BcBody::ModernMsg(ModernMsg {
+                extension: Some(Extension {
+                    channel_id: Some(self.channel_id),
+                    ..Default::default()
+                }),
+                payload: Some(BcPayloads::BcXml(BcXml {
+                    ptz_preset: Some(PtzPreset {
+                        preset_list: PresetList {
+                            preset: vec![preset],
+                        },
                         ..Default::default()
                     }),
                     ..Default::default()

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -13,7 +13,7 @@ use tokio::{
     time::{interval, sleep, Duration},
 };
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) enum Messages {
     Login,
     MotionStop,
@@ -31,7 +31,9 @@ pub(crate) enum Messages {
     PIROff,
     PIRQuery,
     Ptz(Direction),
-    Preset(i8),
+    Preset(u8),
+    PresetAssign(u8, String),
+    PresetQuery,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -544,11 +546,45 @@ impl<'a> MessageHandler<'a> {
                             }
                         }
                         Messages::Preset(id) => {
-                            if let Err(e) = self.camera.set_ptz_preset(id, None).await {
+                            if let Err(e) = self.camera.moveto_ptz_preset(id).await {
                                 error = Some(format!("Failed to send PTZ preset: {:?}", e));
                                 "FAIL".to_string()
                             } else {
                                 "OK".to_string()
+                            }
+                        }
+                        Messages::PresetAssign(id, name) => {
+                            if let Err(e) = self.camera.set_ptz_preset(id, name).await {
+                                error = Some(format!("Failed to send PTZ preset: {:?}", e));
+                                "FAIL".to_string()
+                            } else {
+                                "OK".to_string()
+                            }
+                        }
+                        Messages::PresetQuery => match self.camera.get_ptz_preset().await {
+                            Err(e) => {
+                                error!("Failed to get PTZ preset status: {:?}", e);
+                                "FAIL".to_string()
+                            }
+                            Ok(ptz_info) => {
+                                let bytes_res = yaserde::ser::serialize_with_writer(
+                                    &ptz_info,
+                                    vec![],
+                                    &Default::default(),
+                                );
+                                match bytes_res {
+                                    Ok(bytes) => match String::from_utf8(bytes) {
+                                        Ok(str) => str,
+                                        Err(_) => {
+                                            error!("Failed to encode PTZ preset status");
+                                            "FAIL".to_string()
+                                        }
+                                    },
+                                    Err(_) => {
+                                        error!("Failed to serialise PTZ preset status");
+                                        "FAIL".to_string()
+                                    }
+                                }
                             }
                         }
                         _ => "UNKNOWN COMMAND".to_string(),

--- a/src/mqtt/event_cam.rs
+++ b/src/mqtt/event_cam.rs
@@ -586,7 +586,7 @@ impl<'a> MessageHandler<'a> {
                                     }
                                 }
                             }
-                        }
+                        },
                         _ => "UNKNOWN COMMAND".to_string(),
                     };
                     if let Some(replier) = replier {

--- a/src/ptz/cmdline.rs
+++ b/src/ptz/cmdline.rs
@@ -23,12 +23,10 @@ pub struct Opt {
 
 #[derive(Parser, Debug)]
 pub enum PtzCommand {
-    /// Gets the available presets on the camera, moves the camera to a given preset ID or saves
-    /// the current position as a preset with name and ID.
-    Preset {
-        preset_id: Option<i8>,
-        name: Option<String>,
-    },
+    /// Move to a stored preset
+    Preset { preset_id: Option<u8> },
+    /// Assign the current position to a preset with a given name
+    Assign { preset_id: u8, name: String },
     /// Performs a movement in the given direction
     Control {
         /// The amount to move

--- a/src/ptz/mod.rs
+++ b/src/ptz/mod.rs
@@ -15,7 +15,7 @@
 /// # Move the camera to preset ID 0
 /// neolink ptz --config=config.toml CameraName preset 0
 /// # Save the current position as preset ID 0 with name PresetName
-/// neolink ptz --config=config.toml CameraName preset 0 PresetName
+/// neolink ptz --config=config.toml CameraName assign 0 PresetName
 /// ```
 ///
 use anyhow::{Context, Result};

--- a/src/ptz/mod.rs
+++ b/src/ptz/mod.rs
@@ -37,10 +37,10 @@ pub(crate) async fn main(opt: Opt, config: Config) -> Result<()> {
     let camera = find_and_connect(&config, &opt.camera).await?;
 
     match opt.cmd {
-        PtzCommand::Preset { preset_id, name } => {
-            if preset_id.is_some() {
+        PtzCommand::Preset { preset_id } => {
+            if let Some(preset_id) = preset_id {
                 camera
-                    .set_ptz_preset(preset_id.unwrap(), name)
+                    .moveto_ptz_preset(preset_id)
                     .await
                     .context("Unable to set PTZ preset")
                     .expect("TODO: panic message");
@@ -50,10 +50,17 @@ pub(crate) async fn main(opt: Opt, config: Config) -> Result<()> {
                     .await
                     .context("Unable to get PTZ presets")?;
                 println!("Available presets:\nID Name");
-                for preset in preset_list.preset_list.unwrap().preset {
-                    println!("{:<2} {}", preset.id, preset.name.unwrap());
+                for preset in preset_list.preset_list.preset {
+                    println!("{:<2} {:?}", preset.id, preset.name);
                 }
             }
+        }
+        PtzCommand::Assign { preset_id, name } => {
+            camera
+                .set_ptz_preset(preset_id, name)
+                .await
+                .context("Unable to set PTZ preset")
+                .expect("TODO: panic message");
         }
         PtzCommand::Control {
             amount,


### PR DESCRIPTION
Missing commit from #92 

Adds:
- Readme updates
- Preset assign seperate from set
- Preset query in MQTT interface
