### PR TITLE
Use snap command to make jpeg images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "neolink"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ RUN apt-get update && \
         gstreamer1.0-x \
         gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good \
-        gstreamer1.0-plugins-bad && \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-libav && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build \

--- a/src/image/cmdline.rs
+++ b/src/image/cmdline.rs
@@ -10,4 +10,9 @@ pub struct Opt {
     /// The path of the output.
     #[structopt(short, long, value_parser = PathBuf::from_str)]
     pub file_path: PathBuf,
+    /// If set then the image will pull from the live stream, if not it will be pulled from the cameras snap feature
+    ///
+    /// Using the snap feature, is preffered unless your camera does not support it
+    #[structopt(short, long)]
+    pub use_stream: bool,
 }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -9,6 +9,14 @@
 /// neolink image --config=config.toml --file-path=filepath CameraName
 /// ```
 ///
+/// Cameras that do not support the SNAP command need to use `--use_stream`
+/// which will make the camera play the stream and transcode the video into a jpeg
+/// e.g.:
+///
+/// ```bash
+/// neolink image --config=config.toml --use_stream --file-path=filepath CameraName
+/// ```
+///
 use anyhow::{Context, Result};
 use log::*;
 use neolink_core::{bc_protocol::*, bcmedia::model::*};

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -12,6 +12,7 @@
 use anyhow::{Context, Result};
 use log::*;
 use neolink_core::{bc_protocol::*, bcmedia::model::*};
+use tokio::{fs::File, io::AsyncWriteExt};
 
 mod cmdline;
 mod gst;
@@ -76,9 +77,9 @@ pub(crate) async fn main(opt: Opt, config: Config) -> Result<()> {
         // Simply use the snap command
         debug!("Using the snap command");
         let file_path = opt.file_path.with_extension("jpeg");
-        let mut buffer = File::create(file_path)?;
+        let mut buffer = File::create(file_path).await?;
         let jpeg_data = camera.get_snapshot().await?;
-        buffer.write_all(jpeg_data)?;
+        buffer.write_all(jpeg_data.as_slice()).await?;
     }
 
     Ok(())

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -32,44 +32,54 @@ pub(crate) async fn main(opt: Opt, config: Config) -> Result<()> {
     let camera = connect_and_login(camera_config)
         .await
         .context("Failed to connect to the camera, check credentials and network")?;
-    let mut stream_data = camera
-        .start_video(StreamKind::Main, 0, camera_config.strict)
-        .await
-        .context("Failed to start video")?;
 
-    // Get one iframe at the start while also getting the the video type
-    let buf;
-    let vid_type;
-    loop {
-        if let BcMedia::Iframe(frame) = stream_data.get_data().await?? {
-            vid_type = frame.video_type;
-            buf = frame.data;
-            break;
-        }
-    }
+    if (opt.use_stream) {
+        let mut stream_data = camera
+            .start_video(StreamKind::Main, 0, camera_config.strict)
+            .await
+            .context("Failed to start video")?;
 
-    let mut sender = gst::from_input(vid_type, &opt.file_path).await?;
-    sender.send(buf).await?; // Send first iframe
-
-    // Keep sending both IFrame or PFrame until finished
-    while sender.is_finished().await.is_none() {
-        let buf = match stream_data.get_data().await?? {
-            BcMedia::Iframe(frame) => frame.data,
-            BcMedia::Pframe(frame) => frame.data,
-            _ => {
-                continue;
+        // Get one iframe at the start while also getting the the video type
+        let buf;
+        let vid_type;
+        loop {
+            if let BcMedia::Iframe(frame) = stream_data.get_data().await?? {
+                vid_type = frame.video_type;
+                buf = frame.data;
+                break;
             }
-        };
-
-        debug!("Sending frame data to gstreamer");
-        if sender.send(buf).await.is_err() {
-            // Assume that the sender is closed
-            // because the pipeline is finished
-            break;
         }
+
+        let mut sender = gst::from_input(vid_type, &opt.file_path).await?;
+        sender.send(buf).await?; // Send first iframe
+
+        // Keep sending both IFrame or PFrame until finished
+        while sender.is_finished().await.is_none() {
+            let buf = match stream_data.get_data().await?? {
+                BcMedia::Iframe(frame) => frame.data,
+                BcMedia::Pframe(frame) => frame.data,
+                _ => {
+                    continue;
+                }
+            };
+
+            debug!("Sending frame data to gstreamer");
+            if sender.send(buf).await.is_err() {
+                // Assume that the sender is closed
+                // because the pipeline is finished
+                break;
+            }
+        }
+        debug!("Sending EOS");
+        let _ = sender.eos().await; // Ignore return because if pipeline is finished this will error
+    } else {
+        // Simply use the snap command
+        debug!("Using the snap command");
+        let file_path = opt.file_path.with_extension("jpeg");
+        let mut buffer = File::create(file_path)?;
+        let jpeg_data = camera.get_snapshot().await?;
+        buffer.write_all(jpeg_data)?;
     }
-    debug!("Sending EOS");
-    let _ = sender.eos().await; // Ignore return because if pipeline is finished this will error
 
     Ok(())
 }


### PR DESCRIPTION
This changes the way that the images are generated with the snap command to use the built on snap command of the camera rather then transcoding the live stream