### PR TITLE
Fix registering death spiral

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
@QuantumEntangledAndy thanks a lot for Your work on this fork.

When trying to register for the relay and failing we will most likely select the same relay for the next registration.
This avoids this situation by removing the relays with failing registrations from the pool for current try.

This resolves issues with relay discovery for some 4g cameras that are in other geolocations then our server. 
We were constantly getting the closest of the relays (because it was the first one to get response from during lookup) but if registering failed we entered registering death spiral even if for other relays we could get connection.

Most likely resolves #121 