### PR TITLE
Fix/async lookup and register

### DIFF
--- a/crates/core/src/bc_protocol/connection/mod.rs
+++ b/crates/core/src/bc_protocol/connection/mod.rs
@@ -6,7 +6,7 @@
 //!
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::{net::UdpSocket, task::JoinSet};
+use tokio::net::UdpSocket;
 
 mod bcconn;
 mod bcsub;
@@ -22,16 +22,11 @@ pub(crate) use self::{
 pub(crate) struct DiscoveryResult {
     socket: Arc<UdpSocket>,
     addr: SocketAddr,
-    keep_alive_tasks: JoinSet<()>,
     client_id: i32,
     camera_id: i32,
 }
 
 impl DiscoveryResult {
-    /// Stop all keep alive and any remaining tasks that the discover is managing
-    pub(crate) async fn shutdown(&mut self) {
-        self.keep_alive_tasks.shutdown().await;
-    }
     /// Get the address discovered
     pub(crate) fn get_addr(&self) -> &SocketAddr {
         &self.addr

--- a/crates/core/src/bc_protocol/connection/udpsource.rs
+++ b/crates/core/src/bc_protocol/connection/udpsource.rs
@@ -49,13 +49,12 @@ impl UdpSource {
         Self::new_from_socket(stream, addr, client_id, camera_id, username, password).await
     }
     pub(crate) async fn new_from_discovery<T: Into<String>, U: Into<String>>(
-        mut discovery: DiscoveryResult,
+        discovery: DiscoveryResult,
         username: T,
         password: Option<U>,
     ) -> Result<Self> {
         // Ensure that the discovery keep alive are all stopped here
         // We now handle all coms in UdpSource
-        discovery.shutdown().await;
         Self::new_from_socket(
             discovery.socket,
             discovery.addr,


### PR DESCRIPTION


This attempts to change the way in which reolink registration servers as contacted.

Previously we would stop at the first sucessful reply from one of the reolink servers, but it seems that sometimes those servers had outdated information.

Now we keep waiting for more replies (while trying current replies) and only stop when either all replies fail or full complete and valid registration data is obtained.

We also now only register once rather once per registration method