### PR TITLE
Fix login on new firmware

### DIFF
--- a/crates/core/src/bc/codex.rs
+++ b/crates/core/src/bc/codex.rs
@@ -110,7 +110,7 @@ impl Decoder for BcCodex {
                 match encryption_protocol_byte {
                     0x00 => self.context.set_encrypted(EncryptionProtocol::Unencrypted),
                     0x01 => self.context.set_encrypted(EncryptionProtocol::BCEncrypt),
-                    0x02 => self.context.set_encrypted(EncryptionProtocol::Aes(
+                    0x02 | 0x12 => self.context.set_encrypted(EncryptionProtocol::Aes(
                         self.context.credentials.make_aeskey(nonce),
                     )),
                     _ => {

--- a/crates/core/src/bc/de.rs
+++ b/crates/core/src/bc/de.rs
@@ -159,7 +159,9 @@ fn bc_modern_msg<'a>(
                 msg_id: 1,
                 response_code,
                 ..
-            } if (response_code & 0xff) == 0x02 => EncryptionProtocol::BCEncrypt, // This is AES but the first packet with the NONCE is BCEcrypt, since the NONCE in this packet is required to build the AES key
+            } if (response_code & 0xff) == 0x02 || (response_code & 0xff) == 0x12 => {
+                EncryptionProtocol::BCEncrypt
+            } // This is AES but the first packet with the NONCE is BCEcrypt, since the NONCE in this packet is required to build the AES key
             BcHeader { msg_id: 1, .. }
                 if matches!(context.get_encrypted(), EncryptionProtocol::Aes(_)) =>
             {

--- a/crates/core/src/bc/de.rs
+++ b/crates/core/src/bc/de.rs
@@ -113,8 +113,13 @@ fn bc_modern_msg<'a>(
     };
 
     let mut in_binary = false;
+    let mut encrypted_len = None;
     // Now we'll take the buffer that Nom gave a ref to and parse it.
     let extension = if ext_len > 0 {
+        log::trace!(
+            "Extension Txt: {:?}",
+            String::from_utf8(processed_ext_buf.to_vec()).unwrap_or("Not Text".to_string())
+        );
         // Apply the XML parse function, but throw away the reference to decrypted in the Ok and
         // Err case. This error-error-error thing is the same idiom Nom uses internally.
         let parsed = Extension::try_parse(processed_ext_buf).map_err(|_| {
@@ -126,11 +131,13 @@ fn bc_modern_msg<'a>(
         })?;
         if let Extension {
             binary_data: Some(1),
+            encrypt_len,
             ..
         } = parsed
         {
             // In binary so tell the current context that we need to treat the payload as binary
             in_binary = true;
+            encrypted_len = encrypt_len;
         }
         Some(parsed)
     } else {
@@ -173,13 +180,21 @@ fn bc_modern_msg<'a>(
         let processed_payload_buf =
             xml_crypto::decrypt(header.channel_id as u32, payload_buf, &encryption_protocol);
         if context.in_bin_mode.contains(&(header.msg_num)) || in_binary {
-            payload = match context.get_encrypted() {
-                EncryptionProtocol::FullAes(_) => {
-                    Some(BcPayloads::Binary(processed_payload_buf.to_vec()))
+            payload = match (context.get_encrypted(), encrypted_len) {
+                (EncryptionProtocol::FullAes(_), Some(encrypted_len)) => {
+                    log::trace!("Binary: {:X?}", &processed_payload_buf[0..30]);
+
+                    Some(BcPayloads::Binary(
+                        processed_payload_buf[0..(encrypted_len as usize)].to_vec(),
+                    ))
                 }
                 _ => Some(BcPayloads::Binary(payload_buf.to_vec())),
             };
         } else {
+            log::trace!(
+                "Payload Txt: {:?}",
+                String::from_utf8(processed_payload_buf.to_vec()).unwrap_or("Not Text".to_string())
+            );
             let xml = BcXml::try_parse(processed_payload_buf.as_slice()).map_err(|_| {
                 error!("header.msg_id: {}", header.msg_id);
                 error!(

--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -128,6 +128,8 @@ pub enum LegacyMsg {
         /// Password for a legacy login
         password: String,
     },
+    /// Sent to upgrade to modern and not exposed the MD5 username/password
+    LoginUpgrade,
     /// Any other type of legacy message will be collected here
     UnknownMsg,
 }

--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -200,6 +200,9 @@ pub enum EncryptionProtocol {
     /// Latest cameras/firmwares use Aes with the key derived from
     /// the camera's password and the negotiated NONCE
     Aes([u8; 16]),
+    /// Same as Aes but the media stream is also encrypted and not just
+    /// the control commands
+    FullAes([u8; 16]),
 }
 
 #[derive(Debug)]

--- a/crates/core/src/bc/ser.rs
+++ b/crates/core/src/bc/ser.rs
@@ -130,6 +130,10 @@ fn bc_legacy<W: Write>(legacy: &'_ LegacyMsg) -> impl SerializeFn<W> + '_ {
                     slice(&[0u8; 1772][..]),
                 ))(out)
             }
+            LoginUpgrade => {
+                // Write nothing as it is header only
+                slice(&[])(out)
+            }
             UnknownMsg => {
                 panic!("Cannot serialize an unknown message!");
             }

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -259,6 +259,12 @@ pub struct Extension {
     /// The rfID used in the PIR
     #[yaserde(rename = "rfId")]
     pub rf_id: Option<u8>,
+    /// Encrypted binary has this to verify successful decryption
+    #[yaserde(rename = "checkPos")]
+    pub check_pos: Option<u32>,
+    /// Encrypted binary has this to verify successful decryption
+    #[yaserde(rename = "checkValue")]
+    pub check_value: Option<u32>,
 }
 
 impl Default for Extension {
@@ -270,6 +276,8 @@ impl Default for Extension {
             token: None,
             channel_id: None,
             rf_id: None,
+            check_pos: None,
+            check_value: None,
         }
     }
 }

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -265,6 +265,9 @@ pub struct Extension {
     /// Encrypted binary has this to verify successful decryption
     #[yaserde(rename = "checkValue")]
     pub check_value: Option<u32>,
+    /// Used in newer encrypted payload packets
+    #[yaserde(rename = "encryptLen")]
+    pub encrypt_len: Option<u32>,
 }
 
 impl Default for Extension {
@@ -278,6 +281,7 @@ impl Default for Extension {
             rf_id: None,
             check_pos: None,
             check_value: None,
+            encrypt_len: None,
         }
     }
 }

--- a/crates/core/src/bc/xml_crypto.rs
+++ b/crates/core/src/bc/xml_crypto.rs
@@ -21,7 +21,7 @@ pub fn decrypt(offset: u32, buf: &[u8], encryption_protocol: &EncryptionProtocol
                 .map(|(key, i)| *i ^ key ^ (offset as u8))
                 .collect()
         }
-        EncryptionProtocol::Aes(aeskey) => {
+        EncryptionProtocol::Aes(aeskey) | EncryptionProtocol::FullAes(aeskey) => {
             // AES decryption
 
             let mut decrypted = buf.to_vec();
@@ -41,7 +41,7 @@ pub fn encrypt(offset: u32, buf: &[u8], encryption_protocol: &EncryptionProtocol
             // Encrypt is the same as decrypt
             decrypt(offset, buf, encryption_protocol)
         }
-        EncryptionProtocol::Aes(aeskey) => {
+        EncryptionProtocol::Aes(aeskey) | EncryptionProtocol::FullAes(aeskey) => {
             // AES encryption
             let mut encrypted = buf.to_vec();
             Aes128CfbEnc::new(aeskey.into(), IV.into()).encrypt(&mut encrypted);

--- a/crates/core/src/bc_protocol/connection/bcconn.rs
+++ b/crates/core/src/bc_protocol/connection/bcconn.rs
@@ -295,6 +295,7 @@ impl Poller {
                             if occ_entry.get().is_closed() {
                                 occ_entry.insert(tx);
                             } else {
+                                // log::error!("Failed to subscribe in bcconn to {:?} for {:?}", msg_num, msg_id);
                                 let _ = tx
                                     .send(Err(Error::SimultaneousSubscription { msg_num }))
                                     .await;

--- a/crates/core/src/bc_protocol/connection/discovery.rs
+++ b/crates/core/src/bc_protocol/connection/discovery.rs
@@ -78,12 +78,14 @@ lazy_static! {
 }
 
 type Subscriber = Arc<RwLock<BTreeMap<u32, Sender<Result<(UdpDiscovery, SocketAddr)>>>>>;
+type Handlers = Arc<RwLock<Vec<Sender<Result<(UdpDiscovery, SocketAddr)>>>>>;
 type ArcFramedSocket = UdpFramed<BcUdpCodex, Arc<UdpSocket>>;
 pub(crate) struct Discoverer {
     socket: Arc<UdpSocket>,
     handle: RwLock<JoinSet<()>>,
     writer: Sender<Result<(BcUdp, SocketAddr)>>,
     subsribers: Subscriber,
+    handlers: Handlers,
     local_addr: SocketAddr,
 }
 
@@ -96,26 +98,27 @@ impl Discoverer {
         let (mut writer, mut reader) = inner.split();
         let mut set = JoinSet::new();
         let subsribers: Subscriber = Default::default();
+        let handlers: Handlers = Default::default();
 
         let thread_subscriber = subsribers.clone();
+        let thread_handlers = handlers.clone();
         set.spawn(async move {
             loop {
                 tokio::task::yield_now().await;
                 match reader.next().await {
                     Some(Ok((BcUdp::Discovery(bcudp), addr))) => {
-                        let mut tid = bcudp.tid;
+                        let tid = bcudp.tid;
                         let mut needs_removal = false;
-                        if let Some(sender) = thread_subscriber.read().await.get(&tid) {
+                        if let (Some(sender), true) =
+                            (thread_subscriber.read().await.get(&tid), tid > 0)
+                        {
                             if sender.send(Ok((bcudp, addr))).await.is_err() {
                                 needs_removal = true;
                             }
-                        } else if let Some(any_sender) = thread_subscriber.read().await.get(&0) {
-                            if any_sender.send(Ok((bcudp, addr))).await.is_err() {
-                                tid = 0; // To make is remove 0
-                                needs_removal = true;
-                            }
                         } else {
-                            trace!("Udp Discovery got this unexpected BcUdp {:?}", bcudp);
+                            for sender in thread_handlers.write().await.iter_mut() {
+                                let _ = sender.send(Ok((bcudp.clone(), addr))).await;
+                            }
                         }
                         if needs_removal {
                             thread_subscriber.write().await.remove(&tid);
@@ -148,6 +151,7 @@ impl Discoverer {
             handle: RwLock::new(set),
             writer: sinker,
             subsribers,
+            handlers,
             local_addr,
         })
     }
@@ -157,24 +161,33 @@ impl Discoverer {
     }
 
     async fn subscribe(&self, tid: u32) -> Result<Receiver<Result<(UdpDiscovery, SocketAddr)>>> {
-        let mut subs = self.subsribers.write().await;
-        match subs.entry(tid) {
-            Entry::Vacant(vacant) => {
-                let (tx, rx) = channel(10);
-                vacant.insert(tx);
-                Ok(rx)
-            }
-            Entry::Occupied(mut occ) => {
-                if occ.get().is_closed() {
+        if tid > 0 {
+            let mut subs = self.subsribers.write().await;
+            match subs.entry(tid) {
+                Entry::Vacant(vacant) => {
                     let (tx, rx) = channel(10);
-                    occ.insert(tx);
+                    vacant.insert(tx);
                     Ok(rx)
-                } else {
-                    Err(Error::SimultaneousSubscription {
-                        msg_num: Some(tid as u16),
-                    })
+                }
+                Entry::Occupied(mut occ) => {
+                    if occ.get().is_closed() {
+                        let (tx, rx) = channel(10);
+                        occ.insert(tx);
+                        Ok(rx)
+                    } else {
+                        // log::error!("Failed to subscribe in discovery to {:?}", tid);
+                        Err(Error::SimultaneousSubscription {
+                            msg_num: Some(tid as u16),
+                        })
+                    }
                 }
             }
+        } else {
+            // If tid is zero we listen to all!
+            let mut handlers = self.handlers.write().await;
+            let (tx, rx) = channel(10);
+            handlers.push(tx);
+            Ok(rx)
         }
     }
 

--- a/crates/core/src/bc_protocol/connection/udpsource.rs
+++ b/crates/core/src/bc_protocol/connection/udpsource.rs
@@ -282,7 +282,9 @@ impl UdpPayloadSource {
                 self.send_buffer.push_back(BcUdp::Data(resend.clone()));
             }
         }
-        if self.ack_interval.poll_tick(cx).is_ready() && self.packets_want > 0 {
+        if self.ack_interval.poll_tick(cx).is_ready()
+        // && self.packets_want > 0
+        {
             let ack = BcUdp::Ack(self.build_send_ack());
             self.send_buffer.push_back(ack);
             self.state = State::Flushing;

--- a/crates/core/src/bc_protocol/connection/udpsource.rs
+++ b/crates/core/src/bc_protocol/connection/udpsource.rs
@@ -282,7 +282,7 @@ impl UdpPayloadSource {
                 self.send_buffer.push_back(BcUdp::Data(resend.clone()));
             }
         }
-        if self.ack_interval.poll_tick(cx).is_ready() {
+        if self.ack_interval.poll_tick(cx).is_ready() && self.packets_want > 0 {
             let ack = BcUdp::Ack(self.build_send_ack());
             self.send_buffer.push_back(ack);
             self.state = State::Flushing;

--- a/crates/core/src/bc_protocol/connection/udpsource.rs
+++ b/crates/core/src/bc_protocol/connection/udpsource.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::{
     net::UdpSocket,
-    time::{interval, Duration, Interval},
+    time::{interval, Duration, Instant, Interval},
 };
 use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt};
 use tokio_util::{
@@ -164,6 +164,7 @@ impl BcUdpSource {
             send_buffer: Default::default(),
             ack_interval: interval(Duration::from_millis(10)), // Offical Client does ack every 10ms
             resend_interval: interval(Duration::from_millis(500)), // Offical Client does resend every 500ms
+            ack_latency: Default::default(),
         }
     }
 }
@@ -205,6 +206,57 @@ enum State {
     YieldNow, // Used to ensure we rest between polling packets so as to not starve the runtime
 }
 
+#[derive(Default)]
+struct AckLatency {
+    current_values: Vec<u32>,
+    last_recieve_time: Option<Instant>,
+    display_value: u32,
+    last_display_time: Option<Instant>,
+}
+
+impl AckLatency {
+    /// Used to get the current latency, in thd way that the official
+    /// client does. This is a value that seems to be updated only every second
+    /// Observed values are `0`,    `54785`,    `55062`,     `2528`,
+    fn get_value(&self) -> u32 {
+        self.display_value
+    }
+
+    /// Used to updaet the average latency calculation
+    fn feed_ack(&mut self) {
+        // Update the last recieve time
+        let now = Instant::now();
+        if let Some(last_recieve_time) = self.last_recieve_time {
+            let diff = (now - last_recieve_time).as_micros();
+            self.current_values.push(diff as u32);
+            self.last_recieve_time = Some(now);
+        } else {
+            self.last_recieve_time = Some(now);
+        }
+
+        // Update the display_value
+        // this is done only ever 1s
+        if let Some(last_display_time) = self.last_display_time {
+            if now - last_display_time > Duration::from_secs(1) {
+                // A second has passed update this
+                self.last_display_time = Some(now);
+                let current_values_count = self.current_values.len() as u32;
+                let current_value = self
+                    .current_values
+                    .iter()
+                    .fold(0u32, |acc, value| acc + *value / current_values_count);
+                self.current_values = vec![]; // Reset the average vec
+
+                self.display_value = current_value;
+            }
+        } else {
+            // First 1s is a zero value
+            self.last_display_time = Some(now);
+            self.display_value = 0;
+        }
+    }
+}
+
 pub(crate) struct UdpPayloadSource {
     inner: BcUdpSource,
     client_id: i32,
@@ -222,6 +274,7 @@ pub(crate) struct UdpPayloadSource {
     /// Offical Client does resend every 500ms
     /// This `resend_interval` controls how ofen we do this
     resend_interval: Interval,
+    ack_latency: AckLatency,
 }
 
 impl UdpPayloadSource {
@@ -253,6 +306,7 @@ impl UdpPayloadSource {
                 connection_id: self.camera_id,
                 packet_id: first_missing - 1, // Last we actually have is first_missing - 1
                 group_id: 0,
+                maybe_latency: self.ack_latency.get_value(),
                 payload: missing_ids,
             }
         } else {
@@ -273,6 +327,7 @@ impl UdpPayloadSource {
                 }
             }
         }
+        self.ack_latency.feed_ack();
     }
 
     fn maintanence(&mut self, cx: &mut Context<'_>) {
@@ -282,7 +337,9 @@ impl UdpPayloadSource {
                 self.send_buffer.push_back(BcUdp::Data(resend.clone()));
             }
         }
-        if self.ack_interval.poll_tick(cx).is_ready() && self.packets_want > 0 {
+        if self.ack_interval.poll_tick(cx).is_ready()
+        // && self.packets_want > 0
+        {
             let ack = BcUdp::Ack(self.build_send_ack());
             self.send_buffer.push_back(ack);
             self.state = State::Flushing;

--- a/crates/core/src/bc_protocol/connection/udpsource.rs
+++ b/crates/core/src/bc_protocol/connection/udpsource.rs
@@ -282,9 +282,7 @@ impl UdpPayloadSource {
                 self.send_buffer.push_back(BcUdp::Data(resend.clone()));
             }
         }
-        if self.ack_interval.poll_tick(cx).is_ready()
-        // && self.packets_want > 0
-        {
+        if self.ack_interval.poll_tick(cx).is_ready() && self.packets_want > 0 {
             let ack = BcUdp::Ack(self.build_send_ack());
             self.send_buffer.push_back(ack);
             self.state = State::Flushing;

--- a/crates/core/src/bc_protocol/login.rs
+++ b/crates/core/src/bc_protocol/login.rs
@@ -58,7 +58,7 @@ impl BcCamera {
             let enc_byte = match max_encryption {
                 MaxEncryption::None => 0xdc00,
                 MaxEncryption::BcEncrypt => 0xdc01,
-                MaxEncryption::Aes => 0xdc02,
+                MaxEncryption::Aes => 0xdc12,
             };
             let legacy_login = Bc {
                 meta: BcMeta {

--- a/crates/core/src/bc_protocol/login.rs
+++ b/crates/core/src/bc_protocol/login.rs
@@ -1,4 +1,4 @@
-use super::{md5_string, BcCamera, Error, Result, Truncate, ZeroLast};
+use super::{md5_string, BcCamera, Error, Result, Truncate};
 use crate::bc::{model::*, xml::*};
 use std::sync::atomic::Ordering;
 
@@ -48,12 +48,12 @@ impl BcCamera {
             // Note: I suspect there may be a buffer overflow opportunity in the firmware since in the
             // Baichuan library, these strings are capped at 32 bytes with a null terminator.  This
             // could also be a mistake in the library, the effect being it only compares 31 chars, not 32.
-            let md5_username = md5_string(&credentials.username, ZeroLast);
-            let md5_password = credentials
-                .password
-                .as_ref()
-                .map(|p| md5_string(p, ZeroLast))
-                .unwrap_or_else(|| EMPTY_LEGACY_PASSWORD.to_owned());
+            // let md5_username = md5_string(&credentials.username, ZeroLast);
+            // let md5_password = credentials
+            //     .password
+            //     .as_ref()
+            //     .map(|p| md5_string(p, ZeroLast))
+            //     .unwrap_or_else(|| EMPTY_LEGACY_PASSWORD.to_owned());
 
             let enc_byte = match max_encryption {
                 MaxEncryption::None => 0xdc00,
@@ -69,10 +69,7 @@ impl BcCamera {
                     response_code: enc_byte,
                     class: 0x6514,
                 },
-                body: BcBody::LegacyMsg(LegacyMsg::LoginMsg {
-                    username: md5_username,
-                    password: md5_password,
-                }),
+                body: BcBody::LegacyMsg(LegacyMsg::LoginUpgrade),
             };
 
             sub_login.send(legacy_login).await?;

--- a/crates/core/src/bcudp/de.rs
+++ b/crates/core/src/bcudp/de.rs
@@ -96,7 +96,7 @@ fn udp_ack(buf: &[u8]) -> IResult<&[u8], UdpAck> {
     )(buf)?;
     let (buf, packet_id) = error_context("Missing packet_id", le_u32)(buf)?; // This is the point at which the camera has contigious
                                                                              // packets to
-    let (buf, _unknown) = error_context("ACK: Missing unknown", le_u32)(buf)?;
+    let (buf, maybe_latency) = error_context("ACK: Missing Maybe Latency", le_u32)(buf)?;
     let (buf, payload_size) = error_context("ACK: Missing payload_size", le_u32)(buf)?;
     let (buf, payload) = if payload_size > 0 {
         let (buf, t_payload) = take(payload_size)(buf)?; // It is a binary payload of
@@ -113,6 +113,7 @@ fn udp_ack(buf: &[u8]) -> IResult<&[u8], UdpAck> {
         connection_id,
         packet_id,
         group_id,
+        maybe_latency,
         payload,
     };
     Ok((buf, data))

--- a/crates/core/src/bcudp/model.rs
+++ b/crates/core/src/bcudp/model.rs
@@ -68,8 +68,11 @@ pub struct UdpAck {
     pub group_id: u32,
     /// The ID of the last data packet [`UdpData`]
     pub packet_id: u32,
-    // 2 Bytes Unknown: Observed values `00000000`, `d6010000`, `d7160000` `09e00000`
-    //                  Unknown but seems to change randomly every second
+    /// 4 Bytes Unknown: Observed values `00000000`, `d6010000`, `d7160000`, `09e00000`,
+    ///                                         `0`,    `54785`,    `55062`,     `2528`,
+    ///                  Unknown but seems to change randomly every second
+    /// Might be a latency for the recieved acknoledge packets
+    pub maybe_latency: u32,
     // 2 Bytes size of a payload
     //
     /// Payload of `00 01 01 01 01` where `01` is added after every repeat
@@ -86,6 +89,7 @@ impl UdpAck {
             connection_id,
             group_id: 0xffffffff,
             packet_id: 0xffffffff,
+            maybe_latency: 0x0,
             payload: vec![],
         }
     }

--- a/crates/core/src/bcudp/ser.rs
+++ b/crates/core/src/bcudp/ser.rs
@@ -52,7 +52,7 @@ fn bcudp_ack<'a, W: 'a + Write>(
         le_u32(0),
         le_u32(payload.group_id),
         le_u32(payload.packet_id),
-        le_u32(0xd7160000),
+        le_u32(0),
         le_u32(binary_payload.len() as u32),
         slice(binary_payload),
     ))

--- a/crates/core/src/bcudp/ser.rs
+++ b/crates/core/src/bcudp/ser.rs
@@ -52,7 +52,7 @@ fn bcudp_ack<'a, W: 'a + Write>(
         le_u32(0),
         le_u32(payload.group_id),
         le_u32(payload.packet_id),
-        le_u32(0),
+        le_u32(payload.maybe_latency),
         le_u32(binary_payload.len() as u32),
         slice(binary_payload),
     ))

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,9 @@ pub(crate) struct CameraConfig {
 
     #[serde(default = "default_true", alias = "splash")]
     pub(crate) use_splash: bool,
+
+    #[serde(default = "default_true", alias = "enable")]
+    pub(crate) enabled: bool,
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -95,6 +95,7 @@ pub(crate) async fn main(_: Opt, config: Config) -> Result<()> {
     for camera_config in config
         .cameras
         .iter()
+        .filter(|c| c.enabled)
         .map(|a| Arc::new(a.clone()))
         .collect::<Vec<_>>()
     {

--- a/src/rtsp/mod.rs
+++ b/src/rtsp/mod.rs
@@ -88,7 +88,7 @@ pub(crate) async fn main(_opt: Opt, mut config: Config) -> Result<()> {
         )
     }
     let mut cameras = vec![];
-    for camera_config in config.cameras.drain(..) {
+    for camera_config in config.cameras.drain(..).filter(|c| c.enabled) {
         cameras
             .push(Camera::<Disconnected>::new(camera_config, &config.users, rtsp.clone()).await?);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,6 +153,7 @@ pub(crate) fn find_camera_by_name<'a>(config: &'a Config, name: &str) -> Result<
     config
         .cameras
         .iter()
+        .filter(|c| c.enabled)
         .find(|c| c.name == name)
         .ok_or_else(|| anyhow!("Camera {} not found in the config file", name))
 }


### PR DESCRIPTION
Seems that something is up with login on latest firmware. This PR will try to address that (also fix some other bugs)

- Fixes issue with simulataenous subscrption of discovery message handler.
  Now that all discovery happens with a single handller special care needs to be done to handle the case where multiple threads subscribe to all messages
- Use new contentless login packet
- Don't send -1 ack packets