### PR TITLE
Make listen on motion also fire on AIType

### DIFF
--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -564,6 +564,9 @@ pub struct AlarmEvent {
     pub channel_id: u8,
     /// Motion status. Known values are `"MD"` or `"none"`
     pub status: String,
+    /// AI status. Known values are `"people"` or `"none"`
+    #[yaserde(rename = "AItype")]
+    pub ai_type: Option<String>,
     /// The recording status. Known values `0` or `1`
     pub recording: i32,
     /// The timestamp associated with the recording. `0` if not recording

--- a/crates/core/src/bc_protocol/motion.rs
+++ b/crates/core/src/bc_protocol/motion.rs
@@ -232,10 +232,16 @@ impl BcCamera {
                             let mut result = MotionStatus::NoChange(Instant::now());
                             for alarm_event in &alarm_event_list.alarm_events {
                                 if alarm_event.channel_id == channel_id {
-                                    if alarm_event.status == "MD" {
+                                    if alarm_event.status != "none"
+                                        || alarm_event
+                                            .ai_type
+                                            .as_ref()
+                                            .map(|ai_type| ai_type != "none")
+                                            .unwrap_or(false)
+                                    {
                                         result = MotionStatus::Start(Instant::now());
                                         break;
-                                    } else if alarm_event.status == "none" {
+                                    } else {
                                         result = MotionStatus::Stop(Instant::now());
                                         break;
                                     }


### PR DESCRIPTION
Currently AI events do not trigger motion alarms in mqtt/on_motion pause.

This PR should address this