### PR TITLE
mqtt server was replaced by broker_addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Disabling these may help to conserve battery
 bind = "0.0.0.0"
 
 [[mqtt]]
-server = "127.0.0.1" # Address of the mqtt server
+broker_addr = "127.0.0.1" # Address of the mqtt server
 port = 1883 # mqtt servers port
 credentials = ["username", "password"] # mqtt server login details
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To use mqtt you will need to adjust your config file as such:
 bind = "0.0.0.0"
 
 [[mqtt]]
-server = "127.0.0.1" # Address of the mqtt server
+broker_addr = "127.0.0.1" # Address of the mqtt server
 port = 1883 # mqtt servers port
 credentials = ["username", "password"] # mqtt server login details
 


### PR DESCRIPTION
mqtt.server was changed to mqtt.broker_addr in 0.6.0