### PR TITLE
Attempts to fix talk stability with audio files

### DIFF
--- a/crates/core/src/bc_protocol/talk.rs
+++ b/crates/core/src/bc_protocol/talk.rs
@@ -323,7 +323,7 @@ impl BcCamera {
 
         let full_block_size = block_size + 4; // Block size + predictor state
         let msg_num = self.new_message_num();
-        let sub = connection.subscribe(MSG_ID_TALK, msg_num).await?;
+        let mut sub = connection.subscribe(MSG_ID_TALK, msg_num).await?;
 
         const BLOCK_PER_PAYLOAD: usize = 1;
         const BLOCK_HEADER_SIZE: usize = 4;
@@ -398,6 +398,7 @@ impl BcCamera {
             };
 
             sub.send(msg).await?;
+            let _ = sub.recv().await?;
 
             std::thread::sleep(std::time::Duration::from_secs_f32(play_length * 0.95));
         }

--- a/crates/core/src/bc_protocol/talk.rs
+++ b/crates/core/src/bc_protocol/talk.rs
@@ -333,10 +333,10 @@ impl BcCamera {
 
         let target_chunks = full_block_size as usize * BLOCK_PER_PAYLOAD;
 
-        let mut payload_bytes = vec![];
         let mut end_of_stream = false;
         let mut message_end = std::time::Instant::now();
         while !end_of_stream {
+            let mut payload_bytes = vec![];
             while payload_bytes.len() < target_chunks {
                 let mut buffer = vec![255; target_chunks - payload_bytes.len()];
                 if let Ok(read) = buffered_recv.read(&mut buffer) {
@@ -373,8 +373,6 @@ impl BcCamera {
                 // Zero samples in this block
                 break;
             };
-
-            payload_bytes = vec![];
 
             // Time to play the sample in seconds
             let play_length = samples_sent as f32 / sample_rate as f32;


### PR DESCRIPTION
My goal is to be able to send text-to-speech messages from home assistant to my Reolink Doorbell POE.
The current neolink version has issues for me where the message is cut off too soon, and with longer messages, the neolink executable would never exit.
The never exiting seems to be because the response to the TALK command is not handled, which is tackled in the first commit.
This made the playback choppy, as the thread::sleep after each audio chunk was no longer correct.
I've attempted to fix this by keeping track of when the message should end, and sleeping until just before that before sending a  new chunk. The cutting off of the message early was also fixed by sleeping until just after the supposed message end.

I believe the message_end calculation should work well for audio files, but might start drifting with streamed audio (e.g. microphone). I'm not quite sure how I'd properly tackle that, but I'm open to suggestions.
I also think the talk and talk_stream functions should probably be merged, such that fixes in one do not have to be repeated in the other.

TLDR; Let's have a discussion on whether these are the required fixes or if something else needs work.