### PR TITLE
Adding env vars for containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ FROM docker.io/rust:slim-bookworm AS build
 ARG TARGETPLATFORM
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV NEO_LINK_MODE rtsp
-
-
 WORKDIR /usr/local/src/neolink
 COPY . /usr/local/src/neolink
 
@@ -86,6 +83,8 @@ RUN gst-inspect-1.0; \
     "/usr/local/bin/neolink" --version && \
     mkdir -m 0700 /root/.config/ # Location that the push notifications are cached to
 
-CMD ["/usr/local/bin/neolink", "${NEO_LINK_MODE}", "--config", "/etc/neolink.toml"]
+ENV NEO_LINK_MODE="rtsp" NEO_LINK_PORT=8554
+
+CMD /usr/local/bin/neolink ${NEO_LINK_MODE} --config /etc/neolink.toml
 ENTRYPOINT ["/entrypoint.sh"]
-EXPOSE 8554
+EXPOSE ${NEO_LINK_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM docker.io/rust:slim-bookworm AS build
 ARG TARGETPLATFORM
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV NEO_LINK_MODE rtsp
 
 
 WORKDIR /usr/local/src/neolink
@@ -85,6 +86,6 @@ RUN gst-inspect-1.0; \
     "/usr/local/bin/neolink" --version && \
     mkdir -m 0700 /root/.config/ # Location that the push notifications are cached to
 
-CMD ["/usr/local/bin/neolink", "rtsp", "--config", "/etc/neolink.toml"]
+CMD ["/usr/local/bin/neolink", "${NEO_LINK_MODE}", "--config", "/etc/neolink.toml"]
 ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 8554

--- a/README.md
+++ b/README.md
@@ -456,6 +456,10 @@ docker pull quantumentangledandy/neolink
 # network=host, notably macos lacks this option.
 docker run --network host --volume=$PWD/config.toml:/etc/neolink.toml quantumentangledandy/neolink
 ```
+#### Environmental Variables 
+There are currently 2 environmental variables available as part of the container: 
+- `NEO_LINK_MODE`: defaults to `"rtsp"` if not set, other options are "mqtt" or "mqtt-rtsp".
+- `NEO_LINK_PORT`: defaults to `8554`, set this to your required port value.
 
 ### Image
 


### PR DESCRIPTION
added `NEO_LINK_MODE` to set `rtsp`, `mqtt` or `mqtt-rtsp` respectively as env vars (with a default) and also `NEO_LINK_PORT` with a default along with an updated README