### PR TITLE
fix timed out waiting for camera ping

### DIFF
--- a/src/common/camthread.rs
+++ b/src/common/camthread.rs
@@ -76,7 +76,7 @@ impl NeoCamThread {
                         },
                         Err(_) => {
                             // Timeout
-                            if missed_pings > 5 {
+                            if missed_pings < 5 {
                                 missed_pings += 1;
                                 continue;
                             } else {


### PR DESCRIPTION
Fixes https://github.com/QuantumEntangledAndy/neolink/issues/186 https://github.com/QuantumEntangledAndy/neolink/issues/204
and maybe a few others!

basically `missed_pings` was always 0 and never counting up
because it was checking if it was MORE than 5 rather than LESS than 5

