### PR TITLE
Set JEMALLOC_SYS_WITH_LG_PAGE=16 at build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,7 @@ jobs:
           PKG_CONFIG_ALLOW_CROSS: 1
           PKG_CONFIG_LIBDIR: /usr/lib/${{ matrix.pkgconfig }}/pkgconfig
           TARGET: ${{ matrix.target }}
+          JEMALLOC_SYS_WITH_LG_PAGE: 16
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.arch }}-bookworm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
           echo "GSTREAMER_1_0_ROOT_MSVC_X86_64=${GSTREAMER_1_0_ROOT_MSVC_X86_64}"
           echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"
           # pkg-config --variable pc_path pkg-config
+          export JEMALLOC_SYS_WITH_LG_PAGE=16
           cargo  build --release --all-features
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Support large page sizes becoming more common on arm64 systems. This is compatible with systems that use smaller page sizes.

Related issue: QuantumEntangledAndy/neolink#261