### PR TITLE
Make `resolution` optional in `DeviceInfo`

### DIFF
--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -228,7 +228,8 @@ pub struct DeviceInfo {
     #[serde(rename = "@version")]
     pub version: Option<String>,
     /// The resolution xml block
-    pub resolution: Resolution,
+    /// Does not exist for floodlights
+    pub resolution: Option<Resolution>,
 }
 
 /// VersionInfo xml


### PR DESCRIPTION
Without this change, an error like

```
[2024-07-21T19:26:18Z ERROR neolink_core::bc::de] e: Custom("missing field `resolution`")
[2024-07-21T19:26:18Z WARN  neolink::common::camthread] backyard_floodlight: Connection Lost: Nom Parsing error: Nom Error: VerboseError { errors: [([], Nom(MapRes)), ([], Context("Unable to parse Payload XML"))] }
```

occurs on startup/connection.