### PR TITLE
Remove jemalloc as a depencency in case the build target os is FreeBSD.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ toml = "0.8.2"
 uuid = { version = "1.8.0", features = ["v4"] }
 validator = {version="0.18.1", features = ["derive"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 tikv-jemallocator = "0.5"
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,10 @@
 //!
 //! Neolink source code is available online at <https://github.com/QuantumEntangledAndy/neolink>
 //!
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
Background: the original implementation of jemalloc comes from FreeBSD and is still part of the base system. This will lead to linker errors due to duplicate symbols in case of static build.

https://man.freebsd.org/cgi/man.cgi?jemalloc(3)