### PR TITLE
Don't try to maintain a pool of buffers

### DIFF
--- a/src/rtsp/factory.rs
+++ b/src/rtsp/factory.rs
@@ -1,5 +1,5 @@
 use gstreamer::ClockTime;
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use gstreamer::{prelude::*, Bin, Caps, Element, ElementFactory, FlowError, GhostPad};

--- a/src/rtsp/factory.rs
+++ b/src/rtsp/factory.rs
@@ -245,13 +245,11 @@ pub(super) async fn make_factory(
                         std::thread::spawn(move || {
                             let mut aud_ts = 0u32;
                             let mut vid_ts = 0u32;
-                            let mut pools = Default::default();
 
                             log::trace!("{name}::{stream}: Sending buffered frames");
                             for buffered in buffer.drain(..) {
                                 send_to_sources(
                                     buffered,
-                                    &mut pools,
                                     &vid_src,
                                     &aud_src,
                                     &mut vid_ts,
@@ -264,7 +262,6 @@ pub(super) async fn make_factory(
                             while let Some(data) = media_rx.blocking_recv() {
                                 let r = send_to_sources(
                                     data,
-                                    &mut pools,
                                     &vid_src,
                                     &aud_src,
                                     &mut vid_ts,
@@ -301,7 +298,6 @@ pub(super) async fn make_factory(
 
 fn send_to_sources(
     data: BcMedia,
-    pools: &mut HashMap<usize, gstreamer::BufferPool>,
     vid_src: &Option<AppSrc>,
     aud_src: &Option<AppSrc>,
     vid_ts: &mut u32,
@@ -318,7 +314,6 @@ fn send_to_sources(
                     aud_src,
                     aac.data,
                     Duration::from_micros(*aud_ts as u64),
-                    pools,
                 )?;
             }
             *aud_ts += duration;
@@ -333,7 +328,6 @@ fn send_to_sources(
                     aud_src,
                     adpcm.data,
                     Duration::from_micros(*aud_ts as u64),
-                    pools,
                 )?;
             }
             *aud_ts += duration;
@@ -342,7 +336,7 @@ fn send_to_sources(
         | BcMedia::Pframe(BcMediaPframe { data, .. }) => {
             if let Some(vid_src) = vid_src.as_ref() {
                 log::trace!("Sending VID: {:?}", Duration::from_micros(*vid_ts as u64));
-                send_to_appsrc(vid_src, data, Duration::from_micros(*vid_ts as u64), pools)?;
+                send_to_appsrc(vid_src, data, Duration::from_micros(*vid_ts as u64))?;
             }
             const MICROSECONDS: u32 = 1000000;
             *vid_ts += MICROSECONDS / stream_config.fps;
@@ -356,7 +350,6 @@ fn send_to_appsrc(
     appsrc: &AppSrc,
     data: Vec<u8>,
     mut ts: Duration,
-    pools: &mut HashMap<usize, gstreamer::BufferPool>,
 ) -> AnyResult<()> {
     check_live(appsrc)?; // Stop if appsrc is dropped
 
@@ -383,20 +376,9 @@ fn send_to_appsrc(
     let buf = {
         let msg_size = data.len();
 
-        // Get or create a pool of this len
-        let pool = pools.entry(msg_size).or_insert_with_key(|size| {
-            let pool = gstreamer::BufferPool::new();
-            let mut pool_config = pool.config();
-            // Set a max buffers to ensure we don't grow in memory endlessly
-            pool_config.set_params(None, (*size) as u32, 8, 32);
-            pool.set_config(pool_config).unwrap();
-            pool.set_active(true).unwrap();
-            pool
-        });
-
         // Get a buffer from the pool and then copy in the data
         let gst_buf = {
-            let mut new_buf = pool.acquire_buffer(None).unwrap();
+            let mut new_buf = gstreamer::Buffer::with_size(msg_size).unwrap();
             let gst_buf_mut = new_buf.get_mut().unwrap();
             let time = ClockTime::from_useconds(ts.as_micros() as u64);
             gst_buf_mut.set_dts(time);


### PR DESCRIPTION
I ran into memory issues similar to those in #286, notably the `gst_poll_read_control: assertion 'set != NULL' failed` errors.

My first clue was watching `lsof`: neolink continually opened new fd's until it hit a limit (~1024 on my system), at which point it started throwing the assertion errors, so it seemed like there was something opening way too many fd's.

I then did some poking around with `gdb` and `G_DEBUG=fatal-criticals` as recommended in [this mailing list](https://lists.freedesktop.org/archives/gstreamer-bugs/2017-August/203936.html), which gave me a backtrace for those failed assertions and led me to this code.

I believe this was causing excess memory usage because we were allocating (and keeping permanently in memory, as best I can tell) a pool of pools: for _each unique size of message_, we allocated a new pool of buffers _for that size_, and then held onto it forever.

Which means the memory usage of this pool of pools is a function of the number of **unique message sizes seen** - and at least in my case, judging by some debug logging, the message sizes were essentially random, or at least fairly evenly distributed. Thus, the number of pools we were allocating was functionally unbounded, and we were therefore trying to allocate a _lot_ of permanent pools.

I definitely don't understand the details of what's going on in the rest of the code around this, but this seems like a pretty self-contained change. It seems to me that size-specific buffer pools are intended to be an optimization for the case where you have a small, defined set of common sizes of messages. This does not seem to be the case here: the message sizes, at least in my case, were essentially random.

I thus removed the global pool of pools altogether, and instead simply allocate a new (scoped/limited-lifetime) buffer for every message, which presumably only lives as long as the message.