### PR TITLE
feat(rtsp): fix file descriptor exhaustion and memory fragmentation

### DIFF
--- a/src/rtsp/factory.rs
+++ b/src/rtsp/factory.rs
@@ -354,7 +354,7 @@ fn send_to_sources(
 
 fn bucket_size_for(n: usize) -> Option<usize> {
     const MIN_BUCKET: usize = 256;
-    const MAX_BUCKET: usize = 64 * 1024;
+    const MAX_BUCKET: usize = 1024 * 1024;
     if n == 0 {
         return Some(MIN_BUCKET);
     }


### PR DESCRIPTION
Previously, a new buffer pool was allocated for every received frame-sized package. This led to several critical issues:

- Excessive memory consumption: H264 frames have large variations in size, causing significant memory usage over time.
- File descriptor leaks: Each invocation of `gstreamer::BufferPool::new()` created a new socketpair, resulting in a steady increase in open file descriptors. This can be observed with:

  watch -n1 "ls -l /proc/PID/fd | wc -l"

  Over time, this would exhaust available file descriptors.

- Application instability: On devices such as the Lumus cam, memory usage would continuously rise (over 7-8GiB after 5 hours), eventually leading to a crash.

This commit resolves these issues by reusing buffer pools where possible and preventing unnecessary allocation of resources. This allocates a little bit too much memory for the frames, as it takes the next power of two for the buffer, but its worth it to stabilize the application

Tested-by: Wadim Mueller <wadim.mueller@cmblu.de>