### PR TITLE
Fix timestamp overflow causing stream corruption after ~71 minutes

### DIFF
--- a/src/rtsp/factory.rs
+++ b/src/rtsp/factory.rs
@@ -243,8 +243,8 @@ pub(super) async fn make_factory(
                         // Run blocking code on a seperate thread
                         // This is not an async thread
                         std::thread::spawn(move || {
-                            let mut aud_ts = 0u32;
-                            let mut vid_ts = 0u32;
+                            let mut aud_ts: u64 = 0;
+                            let mut vid_ts: u64 = 0;
                             let mut pools = Default::default();
 
                             log::trace!("{name}::{stream}: Sending buffered frames");
@@ -304,8 +304,8 @@ fn send_to_sources(
     pools: &mut HashMap<usize, gstreamer::BufferPool>,
     vid_src: &Option<AppSrc>,
     aud_src: &Option<AppSrc>,
-    vid_ts: &mut u32,
-    aud_ts: &mut u32,
+    vid_ts: &mut u64,
+    aud_ts: &mut u64,
     stream_config: &StreamConfig,
 ) -> AnyResult<()> {
     // Update TS
@@ -313,39 +313,39 @@ fn send_to_sources(
         BcMedia::Aac(aac) => {
             let duration = aac.duration().expect("Could not calculate AAC duration");
             if let Some(aud_src) = aud_src.as_ref() {
-                log::debug!("Sending AAC: {:?}", Duration::from_micros(*aud_ts as u64));
+                log::debug!("Sending AAC: {:?}", Duration::from_micros(*aud_ts));
                 send_to_appsrc(
                     aud_src,
                     aac.data,
-                    Duration::from_micros(*aud_ts as u64),
+                    Duration::from_micros(*aud_ts),
                     pools,
                 )?;
             }
-            *aud_ts += duration;
+            *aud_ts += duration as u64;
         }
         BcMedia::Adpcm(adpcm) => {
             let duration = adpcm
                 .duration()
                 .expect("Could not calculate ADPCM duration");
             if let Some(aud_src) = aud_src.as_ref() {
-                log::trace!("Sending ADPCM: {:?}", Duration::from_micros(*aud_ts as u64));
+                log::trace!("Sending ADPCM: {:?}", Duration::from_micros(*aud_ts));
                 send_to_appsrc(
                     aud_src,
                     adpcm.data,
-                    Duration::from_micros(*aud_ts as u64),
+                    Duration::from_micros(*aud_ts),
                     pools,
                 )?;
             }
-            *aud_ts += duration;
+            *aud_ts += duration as u64;
         }
         BcMedia::Iframe(BcMediaIframe { data, .. })
         | BcMedia::Pframe(BcMediaPframe { data, .. }) => {
             if let Some(vid_src) = vid_src.as_ref() {
-                log::trace!("Sending VID: {:?}", Duration::from_micros(*vid_ts as u64));
-                send_to_appsrc(vid_src, data, Duration::from_micros(*vid_ts as u64), pools)?;
+                log::trace!("Sending VID: {:?}", Duration::from_micros(*vid_ts));
+                send_to_appsrc(vid_src, data, Duration::from_micros(*vid_ts), pools)?;
             }
-            const MICROSECONDS: u32 = 1000000;
-            *vid_ts += MICROSECONDS / stream_config.fps;
+            const MICROSECONDS: u64 = 1000000;
+            *vid_ts += MICROSECONDS / stream_config.fps as u64;
         }
         _ => {}
     }


### PR DESCRIPTION
## Problem

The video and audio timestamp counters in `send_to_sources` use `u32`, which overflows after approximately 71 minutes of continuous streaming at 30fps:

```
4,294,967,295 / (1,000,000 µs / 30 fps) ≈ 4295 seconds ≈ 71.6 minutes
```

After overflow, timestamps wrap to zero. GStreamer interprets this as a discontinuity and corrupts or drops the stream. This makes Neolink unreliable for any use case requiring continuous streaming beyond ~1 hour (NVR recording, surveillance, home automation).

## Fix

Change `vid_ts` and `aud_ts` from `u32` to `u64`. A `u64` microsecond counter can represent over 584,000 years of continuous streaming, effectively eliminating timestamp overflow as a failure mode.

This is a minimal, targeted change — only the timestamp variables and their immediate usage are affected. No behavior change for streams shorter than 71 minutes.

## Changes

- `src/rtsp/factory.rs`: Change `vid_ts`/`aud_ts` declarations from `0u32` to `u64`
- `src/rtsp/factory.rs`: Update `send_to_sources` signature from `&mut u32` to `&mut u64`
- `src/rtsp/factory.rs`: Update `MICROSECONDS` constant from `u32` to `u64`
- Remove now-unnecessary `as u64` casts on `Duration::from_micros` calls