### PR TITLE
Fix channel backpressure causing keepalive timeout and stream drops

### DIFF
--- a/crates/core/src/bc_protocol/connection/bcconn.rs
+++ b/crates/core/src/bc_protocol/connection/bcconn.rs
@@ -43,10 +43,10 @@ pub struct BcConnection {
 
 impl BcConnection {
     pub async fn new(mut sink: BcConnSink, mut source: BcConnSource) -> Result<BcConnection> {
-        let (sinker, sinker_rx) = channel::<Result<Bc>>(100);
+        let (sinker, sinker_rx) = channel::<Result<Bc>>(500);
         let cancel = CancellationToken::new();
 
-        let (poll_commander, poll_commanded) = channel(200);
+        let (poll_commander, poll_commanded) = channel(1000);
         let mut poller = Poller {
             subscribers: Default::default(),
             sink: sinker.clone(),
@@ -114,7 +114,7 @@ impl BcConnection {
     }
 
     pub async fn subscribe(&self, msg_id: u32, msg_num: u16) -> Result<BcSubscription> {
-        let (tx, rx) = channel(100);
+        let (tx, rx) = channel(500);
         self.poll_commander
             .send(PollCommand::AddSubscriber(msg_id, Some(msg_num), tx))
             .await?;
@@ -151,7 +151,7 @@ impl BcConnection {
     ///
     /// This function creates a temporary handle to grab this single message
     pub async fn subscribe_to_id(&self, msg_id: u32) -> Result<BcSubscription> {
-        let (tx, rx) = channel(100);
+        let (tx, rx) = channel(500);
         self.poll_commander
             .send(PollCommand::AddSubscriber(msg_id, None, tx))
             .await?;
@@ -310,14 +310,26 @@ impl Poller {
                                     };
                                     if let Some(sender) = sender {
                                         if sender.capacity() == 0 {
-                                            warn!("Reaching limit of channel");
-                                            warn!(
-                                                "Remaining: {} of {} message space for {} (ID: {})",
-                                                sender.capacity(),
-                                                sender.max_capacity(),
-                                                &msg_num,
-                                                &msg_id
-                                            );
+                                            // Channel is full. Use try_send to avoid blocking
+                                            // the message loop, which would prevent keepalive
+                                            // ping processing and cause camera disconnection.
+                                            match sender.try_send(Ok(response)) {
+                                                Ok(()) => {
+                                                    trace!(
+                                                        "Sent to full channel for {} (ID: {})",
+                                                        &msg_num,
+                                                        &msg_id
+                                                    );
+                                                }
+                                                Err(_) => {
+                                                    warn!(
+                                                        "Channel full, dropping message for {} (ID: {}), capacity: {}",
+                                                        &msg_num,
+                                                        &msg_id,
+                                                        sender.max_capacity()
+                                                    );
+                                                }
+                                            }
                                         } else {
                                             trace!(
                                                 "Remaining: {} of {} message space for {} (ID: {})",
@@ -326,8 +338,8 @@ impl Poller {
                                                 &msg_num,
                                                 &msg_id
                                             );
+                                            let _ = sender.send(Ok(response)).await;
                                         }
-                                        let _ = sender.send(Ok(response)).await;
                                     } else {
                                         trace!(
                                             "Ignoring uninteresting message id {} (number: {})",

--- a/src/rtsp/factory.rs
+++ b/src/rtsp/factory.rs
@@ -313,13 +313,20 @@ fn send_to_sources(
         BcMedia::Aac(aac) => {
             let duration = aac.duration().expect("Could not calculate AAC duration");
             if let Some(aud_src) = aud_src.as_ref() {
-                log::debug!("Sending AAC: {:?}", Duration::from_micros(*aud_ts as u64));
-                send_to_appsrc(
-                    aud_src,
-                    aac.data,
-                    Duration::from_micros(*aud_ts as u64),
-                    pools,
-                )?;
+                // Drop audio frames when buffer is nearly full to prevent
+                // cascading backpressure that can stall the video pipeline
+                let max = aud_src.max_bytes();
+                if max > 0 && aud_src.current_level_bytes() >= max * 9 / 10 {
+                    log::debug!("Audio buffer near capacity, dropping AAC frame");
+                } else {
+                    log::debug!("Sending AAC: {:?}", Duration::from_micros(*aud_ts as u64));
+                    send_to_appsrc(
+                        aud_src,
+                        aac.data,
+                        Duration::from_micros(*aud_ts as u64),
+                        pools,
+                    )?;
+                }
             }
             *aud_ts += duration;
         }
@@ -328,13 +335,18 @@ fn send_to_sources(
                 .duration()
                 .expect("Could not calculate ADPCM duration");
             if let Some(aud_src) = aud_src.as_ref() {
-                log::trace!("Sending ADPCM: {:?}", Duration::from_micros(*aud_ts as u64));
-                send_to_appsrc(
-                    aud_src,
-                    adpcm.data,
-                    Duration::from_micros(*aud_ts as u64),
-                    pools,
-                )?;
+                let max = aud_src.max_bytes();
+                if max > 0 && aud_src.current_level_bytes() >= max * 9 / 10 {
+                    log::debug!("Audio buffer near capacity, dropping ADPCM frame");
+                } else {
+                    log::trace!("Sending ADPCM: {:?}", Duration::from_micros(*aud_ts as u64));
+                    send_to_appsrc(
+                        aud_src,
+                        adpcm.data,
+                        Duration::from_micros(*aud_ts as u64),
+                        pools,
+                    )?;
+                }
             }
             *aud_ts += duration;
         }


### PR DESCRIPTION
## Problem

When the internal mpsc message channels reach capacity, `send().await` blocks the entire message processing loop in `Poller::run()`. While blocked:

1. Keepalive ping messages from the camera cannot be processed
2. The camera interprets the silence as a dead connection
3. The camera drops the session after its ping timeout expires
4. Neolink enters a reconnection cycle

This is the root cause of streams dying after hours of continuous operation, which users work around with periodic cron restarts.

Additionally, when RTSP clients cannot consume frames fast enough, audio buffer overflow triggers `FlowError::Flushing`, which cascades into the video pipeline causing a full stream reconnection.

## Fix

**1. Increase channel capacities** to reduce how often channels fill under normal load:
- Outgoing message channel: 100 → 500
- Poll command channel: 200 → 1000
- Subscriber channels: 100 → 500

**2. Non-blocking send when channel is full.** When `sender.capacity() == 0`, use `try_send()` instead of the blocking `send().await`. Dropping a single video frame is far better than blocking the message loop and losing the entire camera connection. The normal async `send` path is preserved when capacity is available.

**3. Drop audio frames on buffer overflow.** When the audio AppSrc buffer exceeds 90% capacity, audio frames are silently dropped instead of being pushed. This prevents cascading backpressure from stalling the video pipeline. Audio buffer overflow was triggering pipeline flushing, which caused full stream reconnection cycles.

## Changes

- `crates/core/src/bc_protocol/connection/bcconn.rs`: Increase channel sizes, replace blocking send with try_send at capacity
- `src/rtsp/factory.rs`: Add audio frame dropping when AppSrc buffer is near capacity

## Relationship to Other PRs

The audio frame dropping in this PR is **complementary** to #394, which adds a config option to disable audio entirely. The two approaches serve different use cases:

- **#394**: Hard disable — audio pipeline is never constructed. Best for users who know they don't need audio and want to save CPU permanently.
- **This PR**: Graceful degradation — audio passes through normally but is dropped when the buffer is under pressure. Prevents cascading failures without requiring any configuration change.

Both could be merged. Users who disable audio via #394 would never hit the audio drop path in this PR.

## Related Issues

- #349 — Endless "buffer full" spam making streams unusable
- #346 — Consistent stream drops requiring periodic restarts
- #315 — "Failed to send to source" and "Buffer full on audsrc" errors
- #366 — "Reaching limit of channel: Remaining: 0 of 100" warnings