### PR TITLE
Fix resource exhaustion from per-client GStreamer pipelines

### DIFF
--- a/src/rtsp/gst/factory.rs
+++ b/src/rtsp/gst/factory.rs
@@ -35,11 +35,18 @@ impl Default for NeoMediaFactory {
 impl NeoMediaFactory {
     fn new() -> Self {
         let factory = Object::new::<NeoMediaFactory>();
-        factory.set_shared(false);
+        // Share a single GStreamer pipeline across all RTSP clients.
+        // Without this, each client (go2rtc, ffprobe, health checks) creates
+        // its own pipeline and camera stream session, exhausting resources
+        // and accumulating CLOSE_WAIT connections during 24/7 operation.
+        factory.set_shared(true);
         factory.set_eos_shutdown(false);
         factory.set_stop_on_disconnect(false);
         // factory.set_publish_clock_mode(gstreamer_rtsp_server::RTSPPublishClockMode::Clock);
-        factory.set_suspend_mode(gstreamer_rtsp_server::RTSPSuspendMode::Reset);
+        // Keep the pipeline alive when clients disconnect instead of tearing
+        // it down and rebuilding. Reset mode causes resource churn when
+        // monitoring tools periodically probe the stream.
+        factory.set_suspend_mode(gstreamer_rtsp_server::RTSPSuspendMode::None);
         factory.set_launch("videotestsrc pattern=\"snow\" ! video/x-raw,width=896,height=512,framerate=25/1 ! textoverlay name=\"inittextoverlay\" text=\"Stream not Ready\" valignment=top halignment=left font-desc=\"Sans, 32\" ! jpegenc ! rtpjpegpay name=pay0");
         factory.set_transport_mode(RTSPTransportMode::PLAY);
         factory


### PR DESCRIPTION
## Problem

With the current defaults (`set_shared(false)` and `SuspendMode::Reset`), every RTSP client connection creates its own independent GStreamer pipeline and camera stream session. Each connection — go2rtc, ffprobe, VLC, health check probes — opens a separate Baichuan session with the camera.

During long-running operation this causes:

- **File descriptor exhaustion**: Each pipeline teardown/rebuild cycle leaks UNIX-STREAM socket file descriptors. Over hours, this hits the per-process `nofile` limit, causing GStreamer critical errors (`gst_poll_write_control: assertion 'set != NULL' failed`) and eventually a fatal crash (`Creating pipes for GWakeup: Too many open files`).
- **Memory growth**: Pipeline resources are not fully reclaimed between sessions, causing memory to grow unbounded (users report 18-25GB before OOM).
- **Camera session limits**: Reolink cameras have a limited number of concurrent Baichuan sessions. Multiple independent pipelines can exhaust this limit.
- **CLOSE_WAIT accumulation**: The Reset suspend mode tears down and rebuilds the pipeline on every client connect/disconnect, accumulating TCP connections in CLOSE_WAIT state.

## Fix

Two configuration changes to `NeoMediaFactory`:

1. **`set_shared(true)`**: All RTSP clients share a single GStreamer pipeline. One pipeline, one camera session, regardless of how many clients connect.

2. **`SuspendMode::None`**: Keep the pipeline alive when the last client disconnects, instead of tearing it down. This eliminates the teardown/rebuild cycle that causes resource churn.

Together these changes keep resource usage stable during 24/7 operation with monitoring tools constantly probing the stream.

## Changes

- `src/rtsp/gst/factory.rs`: Change `set_shared(false)` → `set_shared(true)`, `SuspendMode::Reset` → `SuspendMode::None`

## Relationship to Other PRs

This PR is **complementary** to #373 and #340, which address buffer pool proliferation *within* a single pipeline:

- **#373** fixes the unbounded pool-per-frame-size growth with power-of-two bucketing — a valuable optimization even with a shared pipeline, since the single pipeline's pools can still grow.
- **#340** removes pools entirely — simpler but loses the allocation throughput benefits.

This PR operates at a **higher level**: it prevents the *multiplication of pipelines* that amplifies the pool leak. With `set_shared(false)`, every client connection creates its own set of pools, so the FD/memory leak scales with `num_clients × num_unique_frame_sizes`. With `set_shared(true)`, it's just `1 × num_unique_frame_sizes`, which #373's bucketing then bounds to ~12 pools.

Commenters on #373 noted that the pool fix alone did not resolve streaming failures for 4K cameras — the pipeline architecture change in this PR addresses that remaining stability issue.

## Related Issues

- #370 — File descriptor runaway when ffmpeg connects to RTSP port
- #380 — Reconnect loop leaking file descriptors, memory balloon to 18GB
- #366 — Memory leak, 25GB RAM consumed overnight