### PR TITLE
fix: sync camera clock to local wall-clock time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tikv-jemallocator",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rumqttc = "0.24.0"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros", "io-util", "tracing"] }
+time = { version = "0.3", features = ["local-offset"] }
 tokio-stream = "0.1.12"
 tokio-util = { version = "0.7.7", features = ["full", "tracing"] }
 toml = "0.8.2"

--- a/src/common/camthread.rs
+++ b/src/common/camthread.rs
@@ -194,7 +194,11 @@ impl Drop for NeoCamThread {
     }
 }
 
-async fn update_camera_time(camera: &BcCamera, name: &str, update_time: bool) -> AnyResult<()> {
+async fn update_camera_time(
+    camera: &BcCamera,
+    name: &str,
+    update_time: bool,
+) -> AnyResult<()> {
     let cam_time = camera.get_time().await?;
     let mut update = false;
     if let Some(time) = cam_time {
@@ -207,11 +211,21 @@ async fn update_camera_time(camera: &BcCamera, name: &str, update_time: bool) ->
         log::warn!("{}: Camera has no time set, Updating", name);
     }
     if update {
-        use std::time::SystemTime;
-        let new_time = SystemTime::now();
+        use time::{OffsetDateTime, UtcOffset};
 
-        log::info!("{}: Setting time to {:?}", name, new_time);
-        match camera.set_time(new_time.into()).await {
+        let utc_now = OffsetDateTime::now_utc();
+        let offset = UtcOffset::local_offset_at(utc_now).unwrap_or(UtcOffset::UTC);
+        let local = utc_now.to_offset(offset);
+        log::info!(
+            "{}: Setting camera time to local time: {} {}",
+            name,
+            local,
+            offset
+        );
+        // Strip the offset so the camera stores wall-clock local time as-is
+        let new_time = local.replace_offset(UtcOffset::UTC);
+
+        match camera.set_time(new_time).await {
             Ok(_) => {
                 let cam_time = camera.get_time().await?;
                 if let Some(time) = cam_time {


### PR DESCRIPTION
The Baichuan protocol has no timezone field, cameras store whatever time they receive and display it directly. Local wall-clock time is the correct value to send, matching what manufacturer apps do. Sending UTC caused the camera display to show the wrong time for anyone outside UTC.

Uses the system TZ (via TZ env var or /etc/localtime, DST-aware). Falls back to UTC if the local offset cannot be determined. Users who want UTC can set TZ=UTC on the host.

Fixes #361 